### PR TITLE
Fix order of CMake statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,19 +2,18 @@
 
 cmake_minimum_required(VERSION 3.1)
 
+# Project's name
+project(seqwish)
 # We build using c++11
 set(CMAKE_CXX_STANDARD 11)
 
 # We use OpenMP for parallelism
-#find_package(OpenMP)
-#if (OPENMP_FOUND)
+find_package(OpenMP)
+if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -fopenmp")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -fopenmp")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-#endif()
-
-# Project's name
-project(seqwish)
+endif()
 
 # Set the output folder where your program will be created
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)


### PR DESCRIPTION
I tried compiling as-is following the instructions in the readme, and it was having trouble finding some of the open MP dependencies.  I looked in the CMake list and found some things commented out, so I uncommented them.  This caused a new error, `FindOpenMP requires C or CXX language to be enabled`.  I googled it and found https://stackoverflow.com/questions/49937059/findopenmp-requires-c-or-cxx-language-to-be-enabled-error-on-ubuntu-16-04-and-c
Moving the project declaration to the top fixed the problem.
I am not a CMake expert by any means, so I am not sure if this is specific to my environment or not (I happen to be using one of the vg docker build images just now), but thought I would submit my fix in case it is relevant to others.