### PR TITLE
resolve path corruption and always validate paths

### DIFF
--- a/src/compact.cpp
+++ b/src/compact.cpp
@@ -4,7 +4,9 @@
 namespace seqwish {
 
 void compact_nodes(
+    seqindex_t& seqidx,
     size_t graph_size,
+    mmmulti::map<uint64_t, pos_t>& path_mm,
     mmmulti::map<pos_t, pos_t>& link_fwd_mm,
     mmmulti::map<pos_t, pos_t>& link_rev_mm,
     sdsl::bit_vector& seq_id_bv) {
@@ -14,7 +16,7 @@ void compact_nodes(
     // do we have any links to the second that don't come from the first?
     seq_id_bv[0] = 1; // set first node start
 #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 1; i < graph_size; ++i) {
+    for (size_t i = 0; i < graph_size-1; ++i) {
         size_t j = i+1;
         pos_t from = make_pos_t(i, false);
         pos_t to = make_pos_t(j, false);
@@ -28,6 +30,28 @@ void compact_nodes(
             // mark a node start
 #pragma omp critical (seq_id_bv)
             seq_id_bv[i] = 1;
+        }
+    }
+    seq_id_bv[graph_size] = 1;
+    size_t num_seqs = seqidx.n_seqs();
+    for (size_t i = 1; i <= num_seqs; ++i) {
+        size_t j = seqidx.nth_seq_offset(i);
+        size_t k = j+seqidx.nth_seq_length(i)-1;
+        std::vector<pos_t> v1 = path_mm.unique_values(j+1);
+        assert(v1.size() == 1);
+        auto& p1 = v1.front();
+        if (is_rev(p1)) {
+            seq_id_bv[offset(p1)] = 1;
+        } else {
+            seq_id_bv[offset(p1)-1] = 1;
+        }
+        std::vector<pos_t> v2 = path_mm.unique_values(k+1);
+        assert(v2.size() == 1);
+        auto& p2 = v2.front();
+        if (is_rev(p2)) {
+            seq_id_bv[offset(p2)-1] = 1;
+        } else {
+            seq_id_bv[offset(p2)] = 1;
         }
     }
 }

--- a/src/compact.hpp
+++ b/src/compact.hpp
@@ -11,7 +11,9 @@ namespace seqwish {
 
 
 void compact_nodes(
+    seqindex_t& seqidx,
     size_t graph_size,
+    mmmulti::map<uint64_t, pos_t>& path_mm,
     mmmulti::map<pos_t, pos_t>& link_fwd_mm,
     mmmulti::map<pos_t, pos_t>& link_rev_mm,
     sdsl::bit_vector& seq_id_bv);

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -21,10 +21,12 @@ void emit_gfa(std::ostream& out,
     // write the nodes
     // these are delimited in the seq_v_file by the markers in seq_id_civ
     auto show_links = [&](const pos_t& p) { std::cerr << pos_to_string(p) << " " << pos_to_string(make_pos_t(seq_id_cbv_rank(offset(p)), is_rev(p))) << ", "; };
-    size_t n_nodes = seq_id_cbv_rank(seq_id_cbv.size());
+    size_t n_nodes = seq_id_cbv_rank(seq_id_cbv.size()-1);
     for (size_t id = 1; id <= n_nodes; ++id) {
+        //std::cerr << "id " << id << " n_nodes " << n_nodes << std::endl;
         size_t node_start = seq_id_cbv_select(id);
-        size_t node_length = (id==n_nodes ? seq_id_cbv.size() : seq_id_cbv_select(id+1)) - node_start;
+        //size_t node_length = (id==n_nodes ? seq_id_cbv.size() : seq_id_cbv_select(id+1)) - node_start;
+        size_t node_length = seq_id_cbv_select(id+1) - node_start;
         //std::cerr << id << " "  << node_start << " " << node_length << std::endl;
         std::string seq; seq.resize(node_length);
         memcpy((void*)seq.c_str(), &seq_v_buf[node_start], node_length);
@@ -60,7 +62,7 @@ void emit_gfa(std::ostream& out,
         auto print_to_link = [&out, &id, &seq_id_cbv, &seq_id_cbv_rank](const pos_t& p) {
             size_t i = offset(p);
             // internal links which do not go to the head or tail of a compacted node
-            if (!is_rev(p) && (seq_id_cbv[i]||i==seq_id_cbv.size())
+            if (!is_rev(p) && seq_id_cbv[i]
                 || is_rev(p) && seq_id_cbv[i-1]) {
                 pos_t node = make_pos_t(seq_id_cbv_rank(i), is_rev(p));
                 out << "L" << "\t"
@@ -74,7 +76,7 @@ void emit_gfa(std::ostream& out,
             size_t i = offset(p);
             // internal links which do not go to the head or tail of a compacted node
             if (!is_rev(p) && seq_id_cbv[i-1]
-                || is_rev(p) && (seq_id_cbv[i] || i == seq_id_cbv.size())) {
+                || is_rev(p) && seq_id_cbv[i]) {
                 pos_t node = make_pos_t(seq_id_cbv_rank(i), is_rev(p));
                 out << "L" << "\t"
                     << id << "\t" << "+" << "\t"
@@ -87,6 +89,8 @@ void emit_gfa(std::ostream& out,
         link_rev_mm.for_unique_values_of(node_start_fwd, print_to_link);
         //std::cerr << "fwd end" << std::endl;
         link_fwd_mm.for_unique_values_of(node_end_fwd, print_from_link);
+        //pos_t node_start_rev = make_pos_t(node_start+node_length, true);
+        //pos_t node_end_rev = make_pos_t(node_start+1, true);
 
     }
 
@@ -94,24 +98,47 @@ void emit_gfa(std::ostream& out,
     // iterate over the sequence positions, emitting a node at every edge crossing
     size_t num_seqs = seqidx.n_seqs();
     for (size_t i = 1; i <= num_seqs; ++i) {
-        size_t j = seqidx.nth_seq_offset(i) + 1;
-        size_t k = j + seqidx.nth_seq_length(i);
+        size_t j = seqidx.nth_seq_offset(i);
+        size_t seq_len = seqidx.nth_seq_length(i);
+        size_t k = j + seq_len;
         //std::cerr << seqidx.nth_name(i) << " " << seqidx.nth_seq_length(i) << " " << j << " " << k << std::endl;
         std::vector<pos_t> path_v;
+        uint64_t seen_bp = 0;
+        uint64_t accumulated_bp = 0;
         for ( ; j < k; ++j) {
-            std::vector<pos_t> v = path_mm.values(j);
+            std::vector<pos_t> v = path_mm.values(j+1);
             // each input base should only map one place in the graph
             assert(v.size() == 1);
             auto& p = v.front();
             // validate the path
             char c = seq_v_buf[offset(p)-1];
             if (is_rev(p)) c = dna_reverse_complement(c);
-            assert(seqidx.at_pos(make_pos_t(j, false)) == c);
+            assert(seqidx.at_pos(make_pos_t(j+1, false)) == c);
             // are we at the start of a node?
             // if so, write to the path
-            if (seq_id_cbv[offset(p)-1] == 1) {
-                path_v.push_back(make_pos_t(seq_id_cbv_rank(offset(p)), is_rev(p)));
+            //std::cerr << seqidx.nth_name(i) << " " << seqidx.nth_seq_length(i) << " @" << offset(p)-1 << " in seq_v, seen_bp " << seen_bp << " " << accumulated_bp << " " << c << " == " << seqidx.at_pos(make_pos_t(j+1, false)) << std::endl;
+            if (!is_rev(p)) {
+                if (seq_id_cbv[offset(p)-1] == 1) {
+                    size_t id = seq_id_cbv_rank(offset(p));
+                    path_v.push_back(make_pos_t(id, is_rev(p)));
+                    //std::cerr << "adding " << id << "+" << std::endl;
+                    assert(seen_bp == accumulated_bp);
+                    accumulated_bp += seq_id_cbv_select(id+1) - seq_id_cbv_select(id);
+                }
+            } else {
+                if (seq_id_cbv[offset(p)] == 1) {
+                    size_t id = seq_id_cbv_rank(offset(p));
+                    path_v.push_back(make_pos_t(id, is_rev(p)));
+                    //std::cerr << "adding " << id << "-" << std::endl;
+                    assert(seen_bp == accumulated_bp);
+                    accumulated_bp += seq_id_cbv_select(id+1) - seq_id_cbv_select(id);
+                }
             }
+            ++seen_bp;
+        }
+        if (accumulated_bp != seq_len) {
+            std::cerr << "length for " << seqidx.nth_name(i) << ", expected " << seqidx.nth_seq_length(i) << " but got " << accumulated_bp << std::endl;
+            assert(false);
         }
         std::stringstream cigarss;
         std::stringstream pathss;

--- a/src/links.cpp
+++ b/src/links.cpp
@@ -13,10 +13,11 @@ void derive_links(seqindex_t& seqidx,
     size_t num_seqs = seqidx.n_seqs();
     for (size_t i = 1; i <= num_seqs; ++i) {
         size_t j = seqidx.nth_seq_offset(i);
-        size_t k = j+seqidx.nth_seq_length(i);
+        size_t k = j+seqidx.nth_seq_length(i)-1;
         //std::cerr << seqidx.nth_name(i) << " " << seqidx.nth_seq_length(i) << " " << j << " " << k << std::endl;
 #pragma omp parallel for schedule(dynamic)
-        for (size_t q = j; q < k-1; ++q) {
+        for (size_t q = j; q < k; ++q) {
+            //std::cerr << q << std::endl;
             std::vector<pos_t> v1 = path_mm.unique_values(q+1);
             std::vector<pos_t> v2 = path_mm.unique_values(q+2);
             // each input base should only map one place in the graph

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,8 +134,8 @@ int main(int argc, char** argv) {
     }
 
     // 5) generate the node id index (I) by compressing non-bifurcating regions of the graph into nodes
-    sdsl::bit_vector seq_id_bv(graph_length);
-    compact_nodes(graph_length, link_fwd_mm, link_rev_mm, seq_id_bv);
+    sdsl::bit_vector seq_id_bv(graph_length+1);
+    compact_nodes(seqidx, graph_length, path_mm, link_fwd_mm, link_rev_mm, seq_id_bv);
     if (args::get(debug)) std::cerr << seq_id_bv << std::endl;
     sdsl::sd_vector<> seq_id_cbv;
     sdsl::sd_vector<>::rank_1_type seq_id_cbv_rank;

--- a/src/transclosure.cpp
+++ b/src/transclosure.cpp
@@ -104,7 +104,7 @@ size_t compute_transitive_closures(
                     uint64_t seq_id = seqidx.seq_id_at(offset(pos));
                     //std::cerr << "seq id " << seq_id << std::endl;
                     auto& c = seen_seqs[seq_id];
-                    if ((!repeat_max || c < repeat_max)) {
+                    if (!repeat_max || c < repeat_max) {
                         ++c;
                         q_seen_bv[k-1] = 1;
                         todo.insert(std::make_pair(make_pos_t(offset(pos),is_rev(pos)^is_rev(j)), end - start));


### PR DESCRIPTION
This resolves #20 

Path ends were not resulting in node splits, leading to corruption that typically manifested as short increase in path length.