### PR TITLE
iitii everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ set(mmmultimap_INCLUDE "${SOURCE_DIR}/src")
 # mmmultimap (memory mapped multimap)
 ExternalProject_Add(iitii
   GIT_REPOSITORY "https://github.com/ekg/iitii.git"
-  GIT_TAG "43702c29ce40afbc6afbf4d1bcc2f54d30ea46de"
+  GIT_TAG "fd9986f4f35629b737c4a36b71a9b58b5e7761b5"
   BUILD_COMMAND ""
   UPDATE_COMMAND ""
   INSTALL_COMMAND "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,12 +94,23 @@ set(mmmultimap_INCLUDE "${SOURCE_DIR}/src")
 # mmmultimap (memory mapped multimap)
 ExternalProject_Add(iitii
   GIT_REPOSITORY "https://github.com/ekg/iitii.git"
-  GIT_TAG "759e7b36fcce8e4ed385a07d43efddab83821f9c"
+  GIT_TAG "43702c29ce40afbc6afbf4d1bcc2f54d30ea46de"
   BUILD_COMMAND ""
   UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(iitii SOURCE_DIR)
 set(iitii_INCLUDE "${SOURCE_DIR}/src")
+
+ExternalProject_Add(mmap_allocator
+  GIT_REPOSITORY "https://github.com/ekg/mmap_allocator.git"
+  GIT_TAG "ed61daf094de1c2e1adbe8306287ad52da5f0264"
+  BUILD_IN_SOURCE TRUE
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND "make"
+  CONFIGURE_COMMAND "")
+ExternalProject_Get_property(mmap_allocator SOURCE_DIR)
+set(mmap_allocator_INCLUDE "${SOURCE_DIR}")
 
 # In-place Parallel Super Scalar Samplesort (IPS⁴o), header only
 ExternalProject_Add(ips4o
@@ -131,6 +142,7 @@ add_executable(seqwish
   ${CMAKE_SOURCE_DIR}/src/threads.cpp
   ${CMAKE_SOURCE_DIR}/src/exists.cpp
   ${CMAKE_SOURCE_DIR}/src/mmap.cpp
+  ${CMAKE_SOURCE_DIR}/src/iitii_types.cpp
   )
 add_dependencies(seqwish bsort)
 add_dependencies(seqwish tayweeargs)
@@ -138,6 +150,7 @@ add_dependencies(seqwish sdsl-lite)
 add_dependencies(seqwish gzipreader)
 add_dependencies(seqwish mmmultimap)
 add_dependencies(seqwish iitii)
+add_dependencies(seqwish mmap_allocator)
 add_dependencies(seqwish ips4o)
 target_include_directories(seqwish PUBLIC
   "${bsort_INCLUDE}"
@@ -147,12 +160,14 @@ target_include_directories(seqwish PUBLIC
   "${gzipreader_INCLUDE}"
   "${ips4o_INCLUDE}"
   "${mmmultimap_INCLUDE}"
-  "${iitii_INCLUDE}")
+  "${iitii_INCLUDE}"
+  "${mmap_allocator_INCLUDE}")
 target_link_libraries(seqwish
   "${sdsl-lite_LIB}/libsdsl.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
   "${bsort_LIB}/libbsort.a"
+  "${mmap_allocator_INCLUDE}/libmmap_allocator.a"
   "-latomic"
   z)
 if (BUILD_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,12 +84,22 @@ set(gzipreader_INCLUDE "${SOURCE_DIR}")
 # mmmultimap (memory mapped multimap)
 ExternalProject_Add(mmmultimap
   GIT_REPOSITORY "https://github.com/ekg/mmmultimap.git"
-  GIT_TAG "4247c106990c33f5ee16a795fed1d43b72545aaf"
+  GIT_TAG "88c734c36563048b0f3acc04dd8856f19e02b75f"
   BUILD_COMMAND ""
   UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(mmmultimap SOURCE_DIR)
 set(mmmultimap_INCLUDE "${SOURCE_DIR}/src")
+
+# mmmultimap (memory mapped multimap)
+ExternalProject_Add(iitii
+  GIT_REPOSITORY "https://github.com/ekg/iitii.git"
+  GIT_TAG "759e7b36fcce8e4ed385a07d43efddab83821f9c"
+  BUILD_COMMAND ""
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND "")
+ExternalProject_Get_property(iitii SOURCE_DIR)
+set(iitii_INCLUDE "${SOURCE_DIR}/src")
 
 # In-place Parallel Super Scalar Samplesort (IPS⁴o), header only
 ExternalProject_Add(ips4o
@@ -101,7 +111,7 @@ ExternalProject_Add(ips4o
 ExternalProject_Get_property(ips4o SOURCE_DIR)
 set(ips4o_INCLUDE "${SOURCE_DIR}")
 
-set(CMAKE_BUILD_TYPE Debug) 
+set(CMAKE_BUILD_TYPE Release)
 
 # set up our target executable and specify its dependencies and includes
 add_executable(seqwish
@@ -127,6 +137,7 @@ add_dependencies(seqwish tayweeargs)
 add_dependencies(seqwish sdsl-lite)
 add_dependencies(seqwish gzipreader)
 add_dependencies(seqwish mmmultimap)
+add_dependencies(seqwish iitii)
 add_dependencies(seqwish ips4o)
 target_include_directories(seqwish PUBLIC
   "${bsort_INCLUDE}"
@@ -135,7 +146,8 @@ target_include_directories(seqwish PUBLIC
   "${tayweeargs_INCLUDE}"
   "${gzipreader_INCLUDE}"
   "${ips4o_INCLUDE}"
-  "${mmmultimap_INCLUDE}")
+  "${mmmultimap_INCLUDE}"
+  "${iitii_INCLUDE}")
 target_link_libraries(seqwish
   "${sdsl-lite_LIB}/libsdsl.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ ExternalProject_Add(ips4o
 ExternalProject_Get_property(ips4o SOURCE_DIR)
 set(ips4o_INCLUDE "${SOURCE_DIR}")
 
-set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Debug)
 
 # set up our target executable and specify its dependencies and includes
 add_executable(seqwish

--- a/src/alignments.cpp
+++ b/src/alignments.cpp
@@ -3,7 +3,7 @@
 namespace seqwish {
 
 void unpack_paf_alignments(const std::string& paf_file,
-                           mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
+                           range_pos_iitii::builder& aln_iitree_builder,
                            seqindex_t& seqidx,
                            uint64_t min_match_len) {
     // go through the PAF file
@@ -39,11 +39,11 @@ void unpack_paf_alignments(const std::string& paf_file,
                 auto add_match = [&](void) {
                     if (match_len && match_len >= min_match_len) {
                         if (is_rev(q_pos)) {
-                            aln_iitree.add(offset(q_pos)+1, offset(q_pos_match_start)+1, make_pos_t(offset(t_pos)-1, true));
-                            aln_iitree.add(offset(t_pos_match_start), offset(t_pos), make_pos_t(offset(q_pos_match_start), true));
+                            aln_iitree_builder.add({offset(q_pos)+1, offset(q_pos_match_start)+1, make_pos_t(offset(t_pos)-1, true)});
+                            aln_iitree_builder.add({offset(t_pos_match_start), offset(t_pos), make_pos_t(offset(q_pos_match_start), true)});
                         } else {
-                            aln_iitree.add(offset(q_pos_match_start), offset(q_pos), t_pos_match_start);
-                            aln_iitree.add(offset(t_pos_match_start), offset(t_pos), q_pos_match_start);
+                            aln_iitree_builder.add({offset(q_pos_match_start), offset(q_pos), t_pos_match_start});
+                            aln_iitree_builder.add({offset(t_pos_match_start), offset(t_pos), q_pos_match_start});
                         }
                     }
                 };
@@ -81,11 +81,11 @@ void unpack_paf_alignments(const std::string& paf_file,
             }
         }
     }
-    aln_iitree.index();
+    //aln_iitree.index();
 }
 
 void unpack_sxs_alignments(const std::string& sxs_file,
-                           mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
+                           range_pos_iitii::builder& aln_iitree_builder,
                            seqindex_t& seqidx,
                            uint64_t min_match_len) {
     // go through the PAF file
@@ -134,11 +134,11 @@ void unpack_sxs_alignments(const std::string& sxs_file,
                 auto add_match = [&](void) {
                     if (match_len && match_len >= min_match_len) {
                         if (is_rev(q_pos)) {
-                            aln_iitree.add(offset(q_pos)+1, offset(q_pos_match_start)+1, make_pos_t(offset(t_pos)-1, true));
-                            aln_iitree.add(offset(t_pos_match_start), offset(t_pos), make_pos_t(offset(q_pos_match_start), true));
+                            aln_iitree_builder.add({offset(q_pos)+1, offset(q_pos_match_start)+1, make_pos_t(offset(t_pos)-1, true)});
+                            aln_iitree_builder.add({offset(t_pos_match_start), offset(t_pos), make_pos_t(offset(q_pos_match_start), true)});
                         } else {
-                            aln_iitree.add(offset(q_pos_match_start), offset(q_pos), t_pos_match_start);
-                            aln_iitree.add(offset(t_pos_match_start), offset(t_pos), q_pos_match_start);
+                            aln_iitree_builder.add({offset(q_pos_match_start), offset(q_pos), t_pos_match_start});
+                            aln_iitree_builder.add({offset(t_pos_match_start), offset(t_pos), q_pos_match_start});
                         }
                     }
                 };
@@ -176,7 +176,6 @@ void unpack_sxs_alignments(const std::string& sxs_file,
             }
         }
     }
-    aln_iitree.index();
 }
 
 /*

--- a/src/alignments.hpp
+++ b/src/alignments.hpp
@@ -8,6 +8,7 @@
 #include "sxs.hpp"
 #include "mmmultimap.hpp"
 #include "mmiitree.hpp"
+#include "iitii_types.hpp"
 #include "seqindex.hpp"
 #include "gzstream.h"
 #include "pos.hpp"
@@ -16,12 +17,12 @@ namespace seqwish {
 
 
 void unpack_paf_alignments(const std::string& paf_file,
-                           mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
+                           range_pos_iitii::builder& aln_iitree_builder,
                            seqindex_t& seqidx,
                            uint64_t min_match_len);
 
 void unpack_sxs_alignments(const std::string& sxs_file,
-                           mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
+                           range_pos_iitii::builder& aln_iitree_builder,
                            seqindex_t& seqidx,
                            uint64_t min_match_len);
 

--- a/src/compact.cpp
+++ b/src/compact.cpp
@@ -6,8 +6,8 @@ namespace seqwish {
 void compact_nodes(
     seqindex_t& seqidx,
     size_t graph_size,
-    mmmulti::iitree<uint64_t, pos_t>& node_iitree,
-    mmmulti::iitree<uint64_t, pos_t>& path_iitree,
+    range_pos_iitii& node_iitree,
+    range_pos_iitii& path_iitree,
     sdsl::bit_vector& seq_id_bv) {
     // for each pair of positions in the graph base seq
     // do we have any links from the first that don't go to the second?
@@ -21,14 +21,13 @@ void compact_nodes(
         size_t k = j + seq_len;
         //std::cerr << "compact " << seqidx.nth_name(i) << " " << seqidx.nth_seq_length(i) << " " << j << " " << k << std::endl;
         while (j < k) {
-            std::vector<size_t> ovlp;
-            path_iitree.overlap(j, j+1, ovlp);
+            std::vector<range_pos_t> ovlp = path_iitree.overlap(j, j+1);
             // each input base should only map one place in the graph
             assert(ovlp.size() == 1);
-            size_t idx = ovlp.front();
-            uint64_t ovlp_start_in_q = path_iitree.start(idx);
-            uint64_t ovlp_end_in_q = path_iitree.end(idx);
-            pos_t pos_start_in_s = path_iitree.data(idx);
+            auto& o = ovlp.front();
+            auto& ovlp_start_in_q = o.start;
+            auto& ovlp_end_in_q = o.end;
+            auto& pos_start_in_s = o.pos;
             bool match_is_rev = is_rev(pos_start_in_s);
             // mark a node start and end
             pos_t pos_end_in_s = pos_start_in_s;

--- a/src/compact.hpp
+++ b/src/compact.hpp
@@ -5,6 +5,7 @@
 #include "sdsl/bit_vectors.hpp"
 #include "seqindex.hpp"
 #include "mmiitree.hpp"
+#include "iitii_types.hpp"
 #include "pos.hpp"
 
 namespace seqwish {
@@ -13,8 +14,8 @@ namespace seqwish {
 void compact_nodes(
     seqindex_t& seqidx,
     size_t graph_size,
-    mmmulti::iitree<uint64_t, pos_t>& node_iitree,
-    mmmulti::iitree<uint64_t, pos_t>& path_iitree,
+    range_pos_iitii& node_iitree,
+    range_pos_iitii& path_iitree,
     sdsl::bit_vector& seq_id_bv);
 
 }

--- a/src/gfa.cpp
+++ b/src/gfa.cpp
@@ -5,8 +5,8 @@ namespace seqwish {
 void emit_gfa(std::ostream& out,
               size_t graph_length,
               const std::string& seq_v_file,
-              mmmulti::iitree<uint64_t, pos_t>& node_iitree,
-              mmmulti::iitree<uint64_t, pos_t>& path_iitree,
+              range_pos_iitii& node_iitree, // unused
+              range_pos_iitii& path_iitree,
               const sdsl::sd_vector<>& seq_id_cbv,
               const sdsl::sd_vector<>::rank_1_type& seq_id_cbv_rank,
               const sdsl::sd_vector<>::select_1_type& seq_id_cbv_select,
@@ -84,14 +84,13 @@ void emit_gfa(std::ostream& out,
         uint64_t seen_bp = 0;
         uint64_t accumulated_bp = 0;
         while (j < k) {
-            std::vector<size_t> ovlp;
-            path_iitree.overlap(j, j+1, ovlp);
+            std::vector<range_pos_t> ovlp = path_iitree.overlap(j, j+1);
             // each input base should only map one place in the graph
             assert(ovlp.size() == 1);
-            size_t idx = ovlp.front();
-            uint64_t ovlp_start_in_q = path_iitree.start(idx);
-            uint64_t ovlp_end_in_q = path_iitree.end(idx);
-            pos_t pos_start_in_s = path_iitree.data(idx);
+            auto& o = ovlp.front();
+            auto& ovlp_start_in_q = o.start;
+            auto& ovlp_end_in_q = o.end;
+            auto& pos_start_in_s = o.pos;
             bool match_is_rev = is_rev(pos_start_in_s);
             // iterate through the nodes in this range
             uint64_t length = ovlp_end_in_q - ovlp_start_in_q;

--- a/src/gfa.hpp
+++ b/src/gfa.hpp
@@ -8,6 +8,7 @@
 #include "seqindex.hpp"
 #include "pos.hpp"
 #include "mmap.hpp"
+#include "iitii_types.hpp"
 
 namespace seqwish {
 
@@ -15,8 +16,8 @@ namespace seqwish {
 void emit_gfa(std::ostream& out,
               size_t graph_length,
               const std::string& seq_v_file,
-              mmmulti::iitree<uint64_t, pos_t>& node_iitree,
-              mmmulti::iitree<uint64_t, pos_t>& path_iitree,
+              range_pos_iitii& node_iitree,
+              range_pos_iitii& path_iitree,
               const sdsl::sd_vector<>& seq_id_cbv,
               const sdsl::sd_vector<>::rank_1_type& seq_id_cbv_rank,
               const sdsl::sd_vector<>::select_1_type& seq_id_cbv_select,

--- a/src/iitii_types.cpp
+++ b/src/iitii_types.cpp
@@ -1,0 +1,8 @@
+#include "iitii_types.hpp"
+
+namespace seqwish {
+
+uint64_t range_get_beg(const range_pos_t& p) { return p.start; }
+uint64_t range_get_end(const range_pos_t& p) { return p.end; }
+
+}

--- a/src/iitii_types.hpp
+++ b/src/iitii_types.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "iitii.h"
+#include "pos.hpp"
+
+namespace seqwish {
+
+struct range_pos_t {
+    uint64_t start;
+    uint64_t end;
+    pos_t pos;
+};
+uint64_t range_get_beg(const range_pos_t& p);
+uint64_t range_get_end(const range_pos_t& p);
+using range_pos_iitii = iitii::iitii<uint64_t, range_pos_t, range_get_beg, range_get_end>;
+
+}

--- a/src/links.cpp
+++ b/src/links.cpp
@@ -3,8 +3,8 @@
 namespace seqwish {
 
 void derive_links(seqindex_t& seqidx,
-                  mmmulti::iitree<uint64_t, pos_t>& node_iitree,
-                  mmmulti::iitree<uint64_t, pos_t>& path_iitree,
+                  range_pos_iitii& node_iitree,
+                  range_pos_iitii& path_iitree,
                   const sdsl::sd_vector<>& seq_id_cbv,
                   const sdsl::sd_vector<>::rank_1_type& seq_id_cbv_rank,
                   const sdsl::sd_vector<>::select_1_type& seq_id_cbv_select,
@@ -26,13 +26,12 @@ void derive_links(seqindex_t& seqidx,
         //std::cerr << "links for node " << id << " start " << node_start_in_s << " end " << node_end_in_s << std::endl;
         // find the things on both sides of our node by looking in the node_iitree, finding what bits of the paths (in Q)
         // are there, and seeing what's on either side of them to decide what links we need
-        std::vector<size_t> node_ovlp;
-        node_iitree.overlap(node_start_in_s, node_end_in_s, node_ovlp);
-        for (auto& idx : node_ovlp) {
-            uint64_t ovlp_start_in_s = node_iitree.start(idx);
-            uint64_t ovlp_end_in_s = node_iitree.end(idx);
+        std::vector<range_pos_t> node_ovlp = node_iitree.overlap(node_start_in_s, node_end_in_s);
+        for (auto& ovlp : node_ovlp) {
+            auto& ovlp_start_in_s = ovlp.start;
+            auto& ovlp_end_in_s = ovlp.end;
             uint64_t ovlp_length = ovlp_end_in_s - ovlp_start_in_s;
-            pos_t pos_start_in_q = node_iitree.data(idx);
+            auto& pos_start_in_q = ovlp.pos;
             pos_t pos_end_in_q = pos_start_in_q;
             incr_pos(pos_end_in_q, ovlp_length - (ovlp_end_in_s - node_end_in_s) - 1);
             incr_pos(pos_start_in_q, node_start_in_s - ovlp_start_in_s);
@@ -50,19 +49,18 @@ void derive_links(seqindex_t& seqidx,
             uint64_t seq_end = seq_start + seqidx.nth_seq_length(seq_id) - 1;
             //std::cerr << "seq boundaries " << seq_start << "-" << seq_end << std::endl;
             bool curr_step_is_rev = is_rev(pos_start_in_q);
-            std::vector<size_t> path_before_ovlp, path_after_ovlp;
             uint64_t start_in_q = (curr_step_is_rev ? offset(pos_end_in_q) : offset(pos_start_in_q));
             uint64_t end_in_q = (curr_step_is_rev ? offset(pos_start_in_q) : offset(pos_end_in_q)) + 1;
             //std::cerr << "start_in_q " << start_in_q << " end_in_q " << end_in_q << std::endl;
             // and only consider cases where we'd be within the boundaries
             if (start_in_q-1 >= seq_start) {
-                path_iitree.overlap(start_in_q-1, start_in_q, path_before_ovlp);
+                std::vector<range_pos_t> path_before_ovlp = path_iitree.overlap(start_in_q-1, start_in_q);
                 // map these back into positions and orientations in S
-                for (auto& idx : path_before_ovlp) {
+                for (auto& ovlp : path_before_ovlp) {
                     // this is the larger range we're in
-                    uint64_t ovlp_start_in_q = path_iitree.start(idx);
-                    uint64_t ovlp_end_in_q = path_iitree.end(idx);
-                    pos_t pos_start_in_s = path_iitree.data(idx);
+                    auto& ovlp_start_in_q = ovlp.start;
+                    auto& ovlp_end_in_q = ovlp.end;
+                    auto& pos_start_in_s = ovlp.pos;
                     pos_t pos_end_in_s = pos_start_in_s;
                     if (ovlp_end_in_q > start_in_q) {
                         //std::cerr << "contained in previous range on q" << std::endl;
@@ -88,11 +86,11 @@ void derive_links(seqindex_t& seqidx,
                 }
             }
             if (end_in_q+1 <= seq_end) {
-                path_iitree.overlap(end_in_q, end_in_q+1, path_after_ovlp);
-                for (auto& idx : path_after_ovlp) {
-                    uint64_t ovlp_start_in_q = path_iitree.start(idx);
-                    uint64_t ovlp_end_in_q = path_iitree.end(idx);
-                    pos_t pos_start_in_s = path_iitree.data(idx);
+                std::vector<range_pos_t> path_after_ovlp = path_iitree.overlap(end_in_q, end_in_q+1);
+                for (auto& ovlp : path_after_ovlp) {
+                    auto& ovlp_start_in_q = ovlp.start;
+                    auto& ovlp_end_in_q = ovlp.end;
+                    auto& pos_start_in_s = ovlp.pos;
                     if (ovlp_start_in_q < end_in_q) {
                         //std::cerr << "contained in previous range on q" << std::endl;
                         incr_pos(pos_start_in_s, end_in_q - ovlp_start_in_q);

--- a/src/links.hpp
+++ b/src/links.hpp
@@ -7,13 +7,14 @@
 #include "mmmultiset.hpp"
 #include "mmiitree.hpp"
 #include "pos.hpp"
+#include "iitii_types.hpp"
 
 namespace seqwish {
 
 
 void derive_links(seqindex_t& seqidx,
-                  mmmulti::iitree<uint64_t, pos_t>& node_iitree,
-                  mmmulti::iitree<uint64_t, pos_t>& path_iitree,
+                  range_pos_iitii& node_iitree,
+                  range_pos_iitii& path_iitree,
                   const sdsl::sd_vector<>& seq_id_cbv,
                   const sdsl::sd_vector<>::rank_1_type& seq_id_cbv_rank,
                   const sdsl::sd_vector<>::select_1_type& seq_id_cbv_select,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,11 +110,15 @@ int main(int argc, char** argv) {
     std::remove(seq_v_file.c_str());
     std::remove(node_iitree_idx.c_str());
     std::remove(path_iitree_idx.c_str());
-    mmmulti::iitree<uint64_t, pos_t> node_iitree(node_iitree_idx); // maps graph seq to input seq
-    mmmulti::iitree<uint64_t, pos_t> path_iitree(path_iitree_idx); // maps input seq to graph seq
-    size_t graph_length = compute_transitive_closures(seqidx, aln_iitree, seq_v_file, node_iitree, path_iitree,
+    range_pos_iitii::builder node_iitree_builder(node_iitree_idx);
+    range_pos_iitii::builder path_iitree_builder(path_iitree_idx);
+    //mmmulti::iitree<uint64_t, pos_t> node_iitree(node_iitree_idx); // maps graph seq to input seq
+    //mmmulti::iitree<uint64_t, pos_t> path_iitree(path_iitree_idx); // maps input seq to graph seq
+    size_t graph_length = compute_transitive_closures(seqidx, aln_iitree, seq_v_file, node_iitree_builder, path_iitree_builder,
                                                       args::get(repeat_max), args::get(min_transclose_len));
-
+    range_pos_iitii node_iitree = node_iitree_builder.build(n_domains);
+    range_pos_iitii path_iitree = path_iitree_builder.build(n_domains);
+    /*
     if (args::get(debug)) {
         for (auto& interval : node_iitree) {
             std::cerr << "node_iitree " << interval.st << "-" << interval.en << " " << pos_to_string(interval.data) << std::endl;
@@ -123,6 +127,7 @@ int main(int argc, char** argv) {
             std::cerr << "path_iitree " << interval.st << "-" << interval.en << " " << pos_to_string(interval.data) << std::endl;
         }
     }
+    */
 
     // 4) generate the node id index (I) by compressing non-bifurcating regions of the graph into nodes
     sdsl::bit_vector seq_id_bv(graph_length+1);
@@ -155,10 +160,7 @@ int main(int argc, char** argv) {
 
     if (!args::get(keep_temp_files)) {
         seqidx.remove_index_files();
-        //std::remove(aln_idx.c_str());
         std::remove(seq_v_file.c_str());
-        std::remove(node_iitree_idx.c_str());
-        std::remove(path_iitree_idx.c_str());
         link_mmset.close_reader();
         std::remove(link_mm_idx.c_str());
     }

--- a/src/transclosure.cpp
+++ b/src/transclosure.cpp
@@ -7,8 +7,8 @@ size_t compute_transitive_closures(
     seqindex_t& seqidx,
     range_pos_iitii& aln_iitree, // input alignment matches between query seqs
     const std::string& seq_v_file,
-    mmmulti::iitree<uint64_t, pos_t>& node_iitree, // maps graph seq ranges to input seq ranges
-    mmmulti::iitree<uint64_t, pos_t>& path_iitree, // maps input seq ranges to graph seq ranges
+    range_pos_iitii::builder& node_iitree_builder,
+    range_pos_iitii::builder& path_iitree_builder,
     uint64_t repeat_max,
     uint64_t min_transclose_len) {
     // open seq_v_file
@@ -74,8 +74,8 @@ size_t compute_transitive_closures(
                     incr_pos(match_pos_in_q, 1);
                     decr_pos(match_pos_in_s, match_length - 1);
                 }
-                node_iitree.add(match_start_in_s, match_end_in_s, match_pos_in_q);
-                path_iitree.add(match_start_in_q, match_end_in_q, match_pos_in_s);
+                node_iitree_builder.add({match_start_in_s, match_end_in_s, match_pos_in_q});
+                path_iitree_builder.add({match_start_in_q, match_end_in_q, match_pos_in_s});
                 it = range_buffer.erase(it);
             } else {
                 ++it;
@@ -126,7 +126,7 @@ size_t compute_transitive_closures(
             for (auto& s : ovlp) {
                 auto& start = s.start;
                 auto& end = s.end;
-                pos_t pos = s.pos;
+                auto& pos = s.pos;
                 //std::cerr << " with overlap " << start << "-" << end << std::endl;
                 //std::cerr << "and position offset " << offset(pos) << (is_rev(pos)?"-":"+") << std::endl;
                 //std::cerr << "n " << n << " start " << start << std::endl;
@@ -149,9 +149,6 @@ size_t compute_transitive_closures(
     seq_v_out.close();
     flush_ranges(seq_bytes+2);
     assert(range_buffer.empty());
-    // build node_mm and path_mm indexes
-    node_iitree.index();
-    path_iitree.index();
     return seq_bytes;
 }
 

--- a/src/transclosure.cpp
+++ b/src/transclosure.cpp
@@ -5,7 +5,7 @@ namespace seqwish {
 
 size_t compute_transitive_closures(
     seqindex_t& seqidx,
-    mmmulti::iitree<uint64_t, pos_t>& aln_iitree, // input alignment matches between query seqs
+    range_pos_iitii& aln_iitree, // input alignment matches between query seqs
     const std::string& seq_v_file,
     mmmulti::iitree<uint64_t, pos_t>& node_iitree, // maps graph seq ranges to input seq ranges
     mmmulti::iitree<uint64_t, pos_t>& path_iitree, // maps input seq ranges to graph seq ranges
@@ -120,14 +120,13 @@ size_t compute_transitive_closures(
             if (min_transclose_len && match_len < min_transclose_len) {
                 continue;
             }
-            std::vector<size_t> ovlp;
             uint64_t n = offset(j);
             //std::cerr << "offset j " << n << std::endl;
-            aln_iitree.overlap(n, n+1, ovlp);
+            std::vector<range_pos_t> ovlp = aln_iitree.overlap(n, n+1);
             for (auto& s : ovlp) {
-                uint64_t start = aln_iitree.start(s);
-                uint64_t end = aln_iitree.end(s);
-                pos_t pos = aln_iitree.data(s);
+                auto& start = s.start;
+                auto& end = s.end;
+                pos_t pos = s.pos;
                 //std::cerr << " with overlap " << start << "-" << end << std::endl;
                 //std::cerr << "and position offset " << offset(pos) << (is_rev(pos)?"-":"+") << std::endl;
                 //std::cerr << "n " << n << " start " << start << std::endl;

--- a/src/transclosure.hpp
+++ b/src/transclosure.hpp
@@ -9,6 +9,7 @@
 #include "sdsl/bit_vectors.hpp"
 #include "seqindex.hpp"
 #include "mmiitree.hpp"
+#include "iitii_types.hpp"
 #include "pos.hpp"
 
 namespace seqwish {
@@ -16,7 +17,7 @@ namespace seqwish {
 
 size_t compute_transitive_closures(
     seqindex_t& seqidx,
-    mmmulti::iitree<uint64_t, pos_t>& aln_iitree, // input alignment matches between query seqs
+    range_pos_iitii& aln_iitree, // input alignment matches between query seqs
     const std::string& seq_v_file,
     mmmulti::iitree<uint64_t, pos_t>& node_iitree, // maps graph to input
     mmmulti::iitree<uint64_t, pos_t>& path_iitree, // maps input to graph

--- a/src/transclosure.hpp
+++ b/src/transclosure.hpp
@@ -19,8 +19,8 @@ size_t compute_transitive_closures(
     seqindex_t& seqidx,
     range_pos_iitii& aln_iitree, // input alignment matches between query seqs
     const std::string& seq_v_file,
-    mmmulti::iitree<uint64_t, pos_t>& node_iitree, // maps graph to input
-    mmmulti::iitree<uint64_t, pos_t>& path_iitree, // maps input to graph
+    range_pos_iitii::builder& node_iitree_builder,
+    range_pos_iitii::builder& path_iitree_builder,
     uint64_t repeat_max,
     uint64_t min_transclose_len);
 


### PR DESCRIPTION
@mlin, you might be interested to see where this is going.

It seems to be helping seqwish run a little bit faster. However, the model isn't always helping at the scales I'm working at. In the case of the alignment set, iitii improves performance. But this wasn't as much the case for the graph model that seqwish is using. Those might not have the right structure for efficient interpolation. I'll try using the base iit and see if that improves things again.

I see only a handful more optimizations that are worth pursuing. The biggest one is during the transitive closure to build the sequence of the graph, I'm querying for every bp in the entire input sequence set. I should speed things up by using the alignment match information to skip over regions that are homologous.