### PR TITLE
bidirectional check for sequence termination during range extension

### DIFF
--- a/src/transclosure.cpp
+++ b/src/transclosure.cpp
@@ -18,7 +18,7 @@ void extend_range(const uint64_t& s_pos,
     // if one doesn't exist, add the range
     if (f == range_buffer.end()) {
         range_buffer[q_pos] = {s_pos, s_pos+1};
-    } else if (seqidx.seq_start(offset(q_pos))) {
+    } else if (seqidx.seq_start(offset(q_pos)) || (is_rev(q_pos) && seqidx.seq_start(offset(q_last_pos)))) {
         // flush the buffer we found, so we don't extend across node boundaries
         flush_range(f, node_iitree, path_iitree);
         range_buffer.erase(f);


### PR DESCRIPTION
Without this, we sometimes were extending a sequence we shouldn't have, resulting in a length assertion error due to a mismatch between the path and the input sequence.

Resolves #36, and probably a number of other recent issues.