### PR TITLE
reënable --repeat-max to prevent self-looping graph structures

### DIFF
--- a/src/compact.cpp
+++ b/src/compact.cpp
@@ -22,19 +22,17 @@ void compact_nodes(
         //std::cerr << "compact " << seqidx.nth_name(i) << " " << seqidx.nth_seq_length(i) << " " << j << " " << k << std::endl;
         while (j < k) {
             std::vector<size_t> ovlp;
-            //std::cerr <<"overlap at " << j << std::endl;
             path_iitree.overlap(j, j+1, ovlp);
             // each input base should only map one place in the graph
-            //std::cerr << "found " << ovlp.size()  << " overlaps" << std::endl;
-            /*
-            for (auto& o : ovlp) {
-                std::cerr << "ovlp_start_in_q = " << path_iitree.start(o) << " "
-                          << "ovlp_end_in_q = " << path_iitree.end(o) << " "
-                          << "pos_start_in_s = " << pos_to_string(path_iitree.data(o)) << std::endl;
-                //bool match_is_rev = is_rev(pos_start_in_s);
+            if (ovlp.size() != 1) {
+                std::cerr << "found " << ovlp.size()  << " overlaps for seq " << seqidx.nth_name(i) << " idx " << i << " at j=" << j << " of " << k << std::endl;
+                for (auto& o : ovlp) {
+                    std::cerr << "ovlp_start_in_q = " << path_iitree.start(o) << " "
+                              << "ovlp_end_in_q = " << path_iitree.end(o) << " "
+                              << "pos_start_in_s = " << pos_to_string(path_iitree.data(o)) << std::endl;
+                }
+                assert(false);
             }
-            */
-            assert(ovlp.size() == 1);
             size_t idx = ovlp.front();
             uint64_t ovlp_start_in_q = path_iitree.start(idx);
             uint64_t ovlp_end_in_q = path_iitree.end(idx);


### PR DESCRIPTION
This change allows us to set --repeat-max 1, which will prevent any path from looping back on itself in the graph. --repeat-max 2 will allow a single loopback, 3 will allow 2, etc.

Default behavior is unchanged.

Why does this matter? Let's look at one of the simpler regions in the HLA test regions included in this repository: https://github.com/ekg/seqwish/blob/master/test/HLA/B-3106.fa.gz

The default behavior of seqwish produces a problematic looping structure in the graph:

```
seqwish -s B-3106.fa.gz -p B-3106.paf.gz -g B-3106.gfa
vg view -Fdp B-3106.gfa | dot -Tpdf -o B-3106.gfa.k0r0.pdf
```

[B-3106.gfa.k0r0.pdf](https://github.com/ekg/seqwish/files/4486323/B-3106.gfa.k0r0.pdf)

It looks linear, except there are a few regions where something weird is going on:

![Screenshot from 2020-04-16 12-06-41](https://user-images.githubusercontent.com/145425/79444057-efbd9a80-7fda-11ea-8744-d6d1b11b0cf7.png)

![Screenshot from 2020-04-16 12-07-05](https://user-images.githubusercontent.com/145425/79444067-f4824e80-7fda-11ea-8923-9f6e893cae98.png)

Wows. We're really compressing a repeat motif in the graph. This is because the collection of all-vs-all alignments implies that each of the bases in the repeat is mapped to all the other ones. To produce a correct graph, we loop the paths through this motif. The problem is that correct doesn't mean useful. If we try to use GraphAligner to map against this kind of motif, alignments might get stuck in it. Universal motifs in the graph contain any sequence, and are thus equivalent or better mappings for data than the actual graph (because any errors will better match the universal motif than the actual graph).

We can try to mitigate this using the `-k` parameter, which removes short alignments. This helps, but doesn't fix the problem. It's still happening at `-k 32`:

![Screenshot from 2020-04-16 12-12-53](https://user-images.githubusercontent.com/145425/79444753-e3860d00-7fdb-11ea-97a2-01df2adbf590.png)

[B-3106.gfa.k32r0.pdf](https://github.com/ekg/seqwish/files/4486411/B-3106.gfa.k32r0.pdf)

By the time we start eliminating the looping structures (`-k 64`), we have an extremely open graph, with big bubbles caused by a handful of SNPs:

![Screenshot from 2020-04-16 12-14-01](https://user-images.githubusercontent.com/145425/79444726-dbc66880-7fdb-11ea-9738-cec44ec1e173.png)

[B-3106.gfa.k64r0.pdf](https://github.com/ekg/seqwish/files/4486414/B-3106.gfa.k64r0.pdf)

So, that's the problem. How else can we fix it?

In seqwish, I had previously implemented a parameter which prevented the transitive closure from bringing together two bases from the same sequence at the same graph position. This implementation was unstable (different graphs depending on parallel execution order). But, I've figured out how to implement it stably in the current version of seqwish.

Now, we can get rid of loops with a much lower `-k` parameter, without making the graph too open. The `--repeat-max / -r` parameter is used to set the number of times that we allow a path to loop back on itself. The default is `-r 0` or unlimited. Using `-k 8 -r 1` starts to get the right behavior in the tangled region:

![Screenshot from 2020-04-16 12-17-13](https://user-images.githubusercontent.com/145425/79445124-68712680-7fdc-11ea-8102-c619fd22a036.png)

[B-3106.gfa.k8r1.pdf](https://github.com/ekg/seqwish/files/4486417/B-3106.gfa.k8r1.pdf)

The weird motif is caused by a path that traverses the region on the reverse strand of the graph.

Setting `-k 16` further smooths things:

![Screenshot from 2020-04-16 12-17-28](https://user-images.githubusercontent.com/145425/79445203-8b033f80-7fdc-11ea-8740-df60713d5744.png)

[B-3106.gfa.k16r1.pdf](https://github.com/ekg/seqwish/files/4486419/B-3106.gfa.k16r1.pdf)

This isn't ideal (maybe we want to compress it some), but we can leave that up to postprocessing.

In short, this shows how a simple change to the graph induction algorithm can greatly reduce local tangles. With `-r 1`, the graph at a large scale may have looping structures. However, no individual path will ever loop back on itself. This should simplify the use of these graphs as reference structures, such as for SV genotyping.

A further enhancement to this would be only allow looping if it were at a distance greater or less than some threshold. That could allow compressed repeat representations when the repeats are tandem, which _might_ be useful if we do CNV genotyping. We can save this for a future exploration.

CC @maickrau @bpaten @glennhickey @monlong