### PR TITLE
implement min-repeat-distance filter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@ int main(int argc, char** argv) {
     args::ValueFlag<std::string> vgp_base(parser, "BASE", "Write the graph in VGP format with basename FILE", {'o', "vgp-out"});
     args::ValueFlag<uint64_t> num_threads(parser, "N", "Use this many threads during parallel steps", {'t', "threads"});
     args::ValueFlag<uint64_t> repeat_max(parser, "N", "Limit transitive closure to include no more than N copies of a given input base", {'r', "repeat-max"});
+    args::ValueFlag<uint64_t> min_repeat_dist(parser, "N", "Prevent transitive closure for bases at least this far apart in input sequences", {'l', "min-repeat-distance"});
     args::ValueFlag<uint64_t> min_match_len(parser, "N", "Filter exact matches below this length. This can smooth the graph locally and prevent the formation of complex local graph topologies from forming due to differential alignments.", {'k', "min-match-len"});
     args::ValueFlag<uint64_t> transclose_batch(parser, "N", "Number of bp to use for transitive closure batch (default 1M)", {'B', "transclose-batch"});
     //args::ValueFlag<uint64_t> num_domains(parser, "N", "number of domains for iitii interpolation", {'D', "domains"});
@@ -123,6 +124,7 @@ int main(int argc, char** argv) {
     mmmulti::iitree<uint64_t, pos_t> path_iitree(path_iitree_idx); // maps input seq to graph seq
     size_t graph_length = compute_transitive_closures(seqidx, aln_iitree, seq_v_file, node_iitree, path_iitree,
                                                       args::get(repeat_max),
+                                                      args::get(min_repeat_dist),
                                                       !args::get(transclose_batch) ? 1000000 : args::get(transclose_batch));
 
     if (args::get(debug)) {

--- a/src/transclosure.hpp
+++ b/src/transclosure.hpp
@@ -74,6 +74,7 @@ size_t compute_transitive_closures(
     mmmulti::iitree<uint64_t, pos_t>& node_iitree, // maps graph to input
     mmmulti::iitree<uint64_t, pos_t>& path_iitree, // maps input to graph
     uint64_t repeat_max,
+    uint64_t min_repeat_dist,
     uint64_t transclose_batch_size);
 
 }


### PR DESCRIPTION
This behaves like -r 1, but only if the sequences that are being collapsed into the same node are within a given distance.

In effect, setting this to a low number will prevent small self-loops, but allow larger looping copy number variants.