### PR TITLE
Multithreads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ add_executable(seqwish
   ${CMAKE_SOURCE_DIR}/src/vgp.cpp
   ${CMAKE_SOURCE_DIR}/src/threads.cpp
   ${CMAKE_SOURCE_DIR}/src/exists.cpp
+  ${CMAKE_SOURCE_DIR}/src/time.cpp
   ${CMAKE_SOURCE_DIR}/src/mmap.cpp
   ${CMAKE_SOURCE_DIR}/src/iitii_types.cpp
   )

--- a/src/alignments.cpp
+++ b/src/alignments.cpp
@@ -13,7 +13,7 @@ void unpack_paf_alignments(const std::string& paf_file,
                                 std::istreambuf_iterator<char>(), '\n');
     paf_in.close();
     paf_in.open(paf_file.c_str());
-#pragma omp parallel for //schedule(dynamic) // why is this broken now?
+#pragma omp parallel for
     for (size_t i = 0; i < lines; ++i) {
         std::string line;
 #pragma omp critical (paf_in)

--- a/src/compact.cpp
+++ b/src/compact.cpp
@@ -14,7 +14,7 @@ void compact_nodes(
     // do we have any links to the second that don't come from the first?
     seq_id_bv[0] = 1; // set first node start
     size_t num_seqs = seqidx.n_seqs();
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for
     for (size_t i = 1; i <= num_seqs; ++i) {
         size_t j = seqidx.nth_seq_offset(i);
         size_t seq_len = seqidx.nth_seq_length(i);

--- a/src/links.cpp
+++ b/src/links.cpp
@@ -19,7 +19,7 @@ void derive_links(seqindex_t& seqidx,
         std::cerr << i << " rank " << seq_id_cbv_rank(i) << std::endl;
     }
     */
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for
     for (size_t id = 1; id <= n_nodes; ++id) {
         uint64_t node_start_in_s = seq_id_cbv_select(id); // select is 1-based
         uint64_t node_end_in_s = seq_id_cbv_select(id+1);

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -1,0 +1,14 @@
+#include "time.hpp"
+
+namespace seqwish {
+
+uint64_t time_since_epoch_ms(void) {
+  using namespace std::chrono;
+  return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+}
+
+double seconds_since(const std::chrono::time_point<std::chrono::steady_clock>& then) {
+    return ((std::chrono::duration<double>)(std::chrono::steady_clock::now() - then)).count();
+}
+
+}

--- a/src/time.hpp
+++ b/src/time.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+
+namespace seqwish {
+
+uint64_t time_since_epoch_ms(void);
+double seconds_since(const std::chrono::time_point<std::chrono::steady_clock>& then);
+
+}

--- a/src/transclosure.hpp
+++ b/src/transclosure.hpp
@@ -55,7 +55,8 @@ void handle_range(match_t s,
                   const uint64_t& query_start,
                   const uint64_t& query_end,
                   std::vector<std::pair<match_t, bool>>& ovlp,
-                  range_atomic_queue_t& todo,
+                  range_atomic_queue_t& todo_in,
+                  range_atomic_queue_t& todo_out,
                   std::vector<std::pair<pos_t, uint64_t>>& overflow);
 
 void explore_overlaps(const match_t& b,
@@ -64,7 +65,8 @@ void explore_overlaps(const match_t& b,
                       const seqindex_t& seqidx,
                       mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
                       std::vector<std::pair<match_t, bool>>& ovlp,
-                      range_atomic_queue_t& todo,
+                      range_atomic_queue_t& todo_in,
+                      range_atomic_queue_t& todo_out,
                       std::vector<std::pair<pos_t, uint64_t>>& overflow);
 
 size_t compute_transitive_closures(

--- a/src/transclosure.hpp
+++ b/src/transclosure.hpp
@@ -16,8 +16,11 @@
 #include "spinlock.hpp"
 #include "dset64-gccAtomic.hpp"
 #include "atomic_queue.h"
+#include "time.hpp"
 
 namespace seqwish {
+
+#define DEBUG_TRANSCLOSURE true
 
 typedef atomic_queue::AtomicQueue2<std::pair<pos_t, uint64_t>, 2 << 16> range_atomic_queue_t;
 
@@ -55,9 +58,7 @@ void handle_range(match_t s,
                   const uint64_t& query_start,
                   const uint64_t& query_end,
                   std::vector<std::pair<match_t, bool>>& ovlp,
-                  range_atomic_queue_t& todo_in,
-                  range_atomic_queue_t& todo_out,
-                  std::vector<std::pair<pos_t, uint64_t>>& overflow);
+                  range_atomic_queue_t& todo_in);
 
 void explore_overlaps(const match_t& b,
                       atomicbitvector::atomic_bv_t& seen_bv,
@@ -65,9 +66,7 @@ void explore_overlaps(const match_t& b,
                       const seqindex_t& seqidx,
                       mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
                       std::vector<std::pair<match_t, bool>>& ovlp,
-                      range_atomic_queue_t& todo_in,
-                      range_atomic_queue_t& todo_out,
-                      std::vector<std::pair<pos_t, uint64_t>>& overflow);
+                      range_atomic_queue_t& todo_in);
 
 size_t compute_transitive_closures(
     const seqindex_t& seqidx,
@@ -77,6 +76,8 @@ size_t compute_transitive_closures(
     mmmulti::iitree<uint64_t, pos_t>& path_iitree, // maps input to graph
     uint64_t repeat_max,
     uint64_t min_repeat_dist,
-    uint64_t transclose_batch_size);
+    uint64_t transclose_batch_size,
+    bool show_progress,
+    const std::chrono::time_point<std::chrono::steady_clock>& start_time);
 
 }


### PR DESCRIPTION
Correct some problems with multithreading, specifically with the range exploration required to drive the union-find in transclosure.cpp.

Adds verbose progress logging with the `-P` flag.

Corrects some other multithreading bugs that seem to arise when the number of openMP threads is > than the hardware thread count.