### PR TITLE
Manage empty sequences in the fasta and removed mmmap_allocator dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "deps/iitii"]
 	path = deps/iitii
 	url = https://github.com/ekg/iitii.git
-[submodule "deps/mmap_allocator"]
-	path = deps/mmap_allocator
-	url = https://github.com/ekg/mmap_allocator.git
 [submodule "deps/sdsl-lite"]
 	path = deps/sdsl-lite
 	url = https://github.com/simongog/sdsl-lite.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,14 +77,6 @@ ExternalProject_Add(iitii
 ExternalProject_Get_property(iitii SOURCE_DIR)
 set(iitii_INCLUDE "${SOURCE_DIR}/src")
 
-ExternalProject_Add(mmap_allocator
-  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/mmap_allocator"
-  CMAKE_ARGS "${CMAKE_ARGS};-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>"
-  UPDATE_COMMAND "")
-ExternalProject_Get_property(mmap_allocator INSTALL_DIR)
-set(mmap_allocator_INCLUDE "${INSTALL_DIR}/include/mmap_allocator")
-set(mmap_allocator_LIB "${INSTALL_DIR}/lib")
-
 # In-place Parallel Super Scalar Samplesort (IPS⁴o), header only
 ExternalProject_Add(ips4o
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/ips4o"
@@ -184,7 +176,6 @@ add_dependencies(seqwish sdsl-lite)
 add_dependencies(seqwish gzipreader)
 add_dependencies(seqwish mmmulti)
 add_dependencies(seqwish iitii)
-add_dependencies(seqwish mmap_allocator)
 add_dependencies(seqwish ips4o)
 add_dependencies(seqwish bbhash)
 add_dependencies(seqwish atomicbitvector)
@@ -200,7 +191,6 @@ target_include_directories(seqwish PUBLIC
   "${ips4o_INCLUDE}"
   "${mmmulti_INCLUDE}"
   "${iitii_INCLUDE}"
-  "${mmap_allocator_INCLUDE}"
   "${bbhash_INCLUDE}"
   "${atomicbitvector_INCLUDE}"
   "${atomicqueue_INCLUDE}"
@@ -211,7 +201,6 @@ target_link_libraries(seqwish
   "${sdsl-lite_LIB}/libsdsl.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
-  "${mmap_allocator_LIB}/libmmap_allocator.a"
   "-latomic"
   Threads::Threads
   z)

--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -57,11 +57,15 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
             std::getline(in, line); // quality
             std::getline(in, line);
         }
-        // force the sequence to be upper-case
-        std::transform(seq.begin(), seq.end(), seq.begin(), [](char c) { return std::toupper(c); });
-        seqout << seq;
-        // record where the sequence starts
-        seq_bytes_written += seq.size();
+        if (seq.empty()){
+            std::cerr << "[seqwish] WARNING: input FASTA file contains empty sequences." << std::endl;
+        } else {
+            // force the sequence to be upper-case
+            std::transform(seq.begin(), seq.end(), seq.begin(), [](char c) { return std::toupper(c); });
+            seqout << seq;
+            // record where the sequence starts
+            seq_bytes_written += seq.size();
+        }
     }
     in.close();
     // add the last value so we can get sequence length for the last sequence and name

--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -35,9 +35,6 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
     size_t seq_names_bytes_written = 0;
     bool notified_empty_seqs = false;
     while (in.good()) {
-        seqname_offset.push_back(seq_names_bytes_written);
-        seq_offset.push_back(seq_bytes_written);
-
         line[0] = '>';
         std::string seq_name = line.substr(0, line.find(" "));
 
@@ -64,6 +61,9 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
                 std::cerr << "[seqwish] WARNING: input FASTA file contains empty sequences, which will be ignored." << std::endl;
             }
         } else {
+            seqname_offset.push_back(seq_names_bytes_written);
+            seq_offset.push_back(seq_bytes_written);
+
             seqnames << seq_name << " ";
             seq_names_bytes_written += seq_name.size() + 1;
 

--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -65,7 +65,7 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
             }
         } else {
             seqnames << seq_name << " ";
-            seq_names_bytes_written += line.size() + 1;
+            seq_names_bytes_written += seq_name.size() + 1;
 
             // force the sequence to be upper-case
             std::transform(seq.begin(), seq.end(), seq.begin(), [](char c) { return std::toupper(c); });

--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -33,6 +33,7 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
     }
     size_t seq_bytes_written = 0;
     size_t seq_names_bytes_written = 0;
+    bool notified_empty_seqs = false;
     while (in.good()) {
         seqname_offset.push_back(seq_names_bytes_written);
         seq_offset.push_back(seq_bytes_written);
@@ -51,13 +52,16 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
                 }
             }
         } else if (input_is_fastq) {
-            std::getline(in, seq); // sequence
+            std::getline(in, seq);  // sequence
             std::getline(in, line); // delimiter
             std::getline(in, line); // quality
             std::getline(in, line);
         }
         if (seq.empty()){
-            std::cerr << "[seqwish] WARNING: input FASTA file contains empty sequences." << std::endl;
+            if (!notified_empty_seqs){
+                notified_empty_seqs = true;
+                std::cerr << "[seqwish] WARNING: the input FASTA file contains empty sequences, which will be ignored." << std::endl;
+            }
         } else {
             seqnames << seq_name << " ";
             seq_names_bytes_written += line.size() + 1;

--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -37,9 +37,8 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
         seqname_offset.push_back(seq_names_bytes_written);
         seq_offset.push_back(seq_bytes_written);
         line[0] = '>';
-        line = line.substr(0, line.find(" "));
-        seqnames << line << " ";
-        seq_names_bytes_written += line.size() + 1;
+        std::string seq_name = line.substr(0, line.find(" "));
+
         std::string seq;
         // get the sequence
         if (input_is_fasta) {
@@ -60,6 +59,9 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
         if (seq.empty()){
             std::cerr << "[seqwish] WARNING: input FASTA file contains empty sequences." << std::endl;
         } else {
+            seqnames << seq_name << " ";
+            seq_names_bytes_written += line.size() + 1;
+
             // force the sequence to be upper-case
             std::transform(seq.begin(), seq.end(), seq.begin(), [](char c) { return std::toupper(c); });
             seqout << seq;

--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -37,6 +37,7 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
     while (in.good()) {
         seqname_offset.push_back(seq_names_bytes_written);
         seq_offset.push_back(seq_bytes_written);
+
         line[0] = '>';
         std::string seq_name = line.substr(0, line.find(" "));
 
@@ -60,7 +61,7 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
         if (seq.empty()){
             if (!notified_empty_seqs){
                 notified_empty_seqs = true;
-                std::cerr << "[seqwish] WARNING: the input FASTA file contains empty sequences, which will be ignored." << std::endl;
+                std::cerr << "[seqwish] WARNING: input FASTA file contains empty sequences, which will be ignored." << std::endl;
             }
         } else {
             seqnames << seq_name << " ";
@@ -106,7 +107,7 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
     std::remove(seqnamefile.c_str());
 
     if (duplicated_ids){
-        std::cerr << "[seqwish] ERROR: the input sequences have duplicated IDs." << std::endl;
+        std::cerr << "[seqwish] ERROR: input sequences have duplicated IDs." << std::endl;
         exit(1);
     }
 


### PR DESCRIPTION
This PR manages correctly cases when the input multiFASTA contains empty sequences, also reporting a warning in the log.

This removes also the unused mmap_allocator dependency.