### PR TITLE
Parallelize the mapping of collection of bases from the full sequence set into a dense range

### DIFF
--- a/src/alignments.cpp
+++ b/src/alignments.cpp
@@ -25,9 +25,9 @@ void paf_worker(
             // Query/Target end (0-based; BED-like; open)
             paf.target_start >= paf.target_sequence_length || paf.target_end > paf.target_sequence_length || paf.target_start >= paf.target_end) break;
         size_t query_idx = seqidx.rank_of_seq_named(paf.query_sequence_name);
-        size_t query_len = seqidx.nth_seq_length(query_idx);
+        //size_t query_len = seqidx.nth_seq_length(query_idx);
         size_t target_idx = seqidx.rank_of_seq_named(paf.target_sequence_name);
-        size_t target_len = seqidx.nth_seq_length(target_idx);
+        //size_t target_len = seqidx.nth_seq_length(target_idx);
         bool q_rev = !paf.query_target_same_strand;
         size_t q_all_pos = (q_rev ? seqidx.pos_in_all_seqs(query_idx, paf.query_end, false) - 1
                             : seqidx.pos_in_all_seqs(query_idx, paf.query_start, false));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,8 +117,8 @@ int main(int argc, char** argv) {
     seqidx.save();
     if (args::get(show_progress)) std::cerr << "[seqwish::seqidx] " << std::fixed << std::showpoint << std::setprecision(3) << seconds_since(start_time) << " index built" << std::endl;
 
-    if (args::get(show_progress)) std::cerr << "[seqwish::alignments] " << std::fixed << std::showpoint << std::setprecision(3) << seconds_since(start_time) << " processing alignments" << std::endl;
     // 2) parse the alignments into position pairs and index (A)
+    if (args::get(show_progress)) std::cerr << "[seqwish::alignments] " << std::fixed << std::showpoint << std::setprecision(3) << seconds_since(start_time) << " processing alignments" << std::endl;
     std::string aln_idx = work_base + ".sqa";
     std::remove(aln_idx.c_str());
     auto aln_iitree_ptr = std::make_unique<mmmulti::iitree<uint64_t, pos_t>>(aln_idx);
@@ -162,7 +162,7 @@ int main(int argc, char** argv) {
     size_t graph_length = compute_transitive_closures(seqidx, aln_iitree, seq_v_file, node_iitree, path_iitree,
                                                       args::get(repeat_max),
                                                       args::get(min_repeat_dist),
-                                                      transclose_batch ? seqwish::handy_parameter(args::get(transclose_batch), 1000000) : 1000000,
+                                                      transclose_batch ? (uint64_t)seqwish::handy_parameter(args::get(transclose_batch), 1000000) : 1000000,
                                                       args::get(show_progress),
                                                       num_threads,
                                                       start_time);
@@ -201,8 +201,8 @@ int main(int argc, char** argv) {
     derive_links(seqidx, node_iitree, path_iitree, seq_id_cbv, seq_id_cbv_rank, seq_id_cbv_select, link_mmset, num_threads);
     if (args::get(show_progress)) std::cerr << "[seqwish::links] " << std::fixed << std::showpoint << std::setprecision(3) << seconds_since(start_time) << " links derived" << std::endl;
 
-    if (args::get(show_progress)) std::cerr << "[seqwish::gfa] " << std::fixed << std::showpoint << std::setprecision(3) << seconds_since(start_time) << " writing graph" << std::endl;
     // 6) emit the graph in GFA or VGP format
+    if (args::get(show_progress)) std::cerr << "[seqwish::gfa] " << std::fixed << std::showpoint << std::setprecision(3) << seconds_since(start_time) << " writing graph" << std::endl;
     if (!args::get(gfa_out).empty()) {
         std::ofstream out(args::get(gfa_out).c_str());
         emit_gfa(out, graph_length, seq_v_file, node_iitree, path_iitree, seq_id_cbv, seq_id_cbv_rank, seq_id_cbv_select, seqidx, link_mmset, num_threads);

--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -36,7 +36,7 @@ void seqindex_t::build_index(const std::string& filename, const std::string& idx
     bool notified_empty_seqs = false;
     while (in.good()) {
         line[0] = '>';
-        std::string seq_name = line.substr(0, line.find(" "));
+        std::string seq_name = line.substr(0, line.find(' '));
 
         std::string seq;
         // get the sequence

--- a/src/transclosure.cpp
+++ b/src/transclosure.cpp
@@ -456,15 +456,19 @@ size_t compute_transitive_closures(
         // use a rank support to make a dense mapping from the current bases to an integer range
         // ... pre-allocate default values
         std::vector<uint64_t> q_curr_bv_vec; q_curr_bv_vec.resize(q_curr_bv_count);
-        // ... prepare offset in the vector to fill: we already know the number of items that will come from each range.
-        // ...... range 0 elements will be inserted from the position 0
-        // ...... range 1 elements will be inserted from the position num_element_range_0
-        // ...... range N elements will be inserted from the position num_element_range_0+1+...+N-1
-        uint64_t current_starting_pos_for_range = q_curr_bv_count;
-        for(int64_t num_range = (int64_t)ranges.size() - 1; num_range >= 0; --num_range) {
-            current_starting_pos_for_range -= q_curr_bv_counts[num_range];
-            q_curr_bv_counts[num_range] = current_starting_pos_for_range;
+        // ... prepare offsets in the vector to fill: we already know the number of items that will come from each range.
+        {
+            // ...... range 0 elements will be inserted from the position 0
+            // ...... range 1 elements will be inserted from the position num_element_range_0
+            // ...... range N elements will be inserted from the position num_element_range_0+1+...+N-1
+            uint64_t current_starting_pos_for_range = q_curr_bv_count;
+            for(int64_t num_range = (int64_t)ranges.size() - 1; num_range >= 0; --num_range) {
+                current_starting_pos_for_range -= q_curr_bv_counts[num_range];
+                q_curr_bv_counts[num_range] = current_starting_pos_for_range;
+            }
         }
+
+        // ... fill in parallel
         paryfor::parallel_for<uint64_t>(
                 0, ranges.size(), num_threads,
                 [&](uint64_t num_range, int tid) {

--- a/src/transclosure.cpp
+++ b/src/transclosure.cpp
@@ -451,14 +451,11 @@ size_t compute_transitive_closures(
             }
 
             // ... fill the vector in parallel
-            uint64_t num_elements_inserted[num_threads];
-            for(uint64_t tid = 0; tid < num_threads; ++tid) { num_elements_inserted[tid] = 0; }
             paryfor::parallel_for<uint64_t>(
                     0, q_curr_bv.size(), num_threads, q_curr_bv.size()/num_threads,
                     [&](uint64_t i, int tid) {
                         if (q_curr_bv[i]) {
-                            q_curr_bv_vec[q_curr_bv_counts[tid] + num_elements_inserted[tid]] = i;
-                            ++num_elements_inserted[tid];
+                            q_curr_bv_vec[q_curr_bv_counts[tid]++] = i;
                         }
                     });
         }


### PR DESCRIPTION
This parallelizes the two steps that have become the bottlenecks of the whole process, that it the mapping of the collection of bases from the full sequence set into a dense range (needed for the union-find algorithm to work on). Parallelization makes the two steps ~2.5X faster when tested with 16 threads on little/medium graphs, which results in an entire graph induction runtime improvements of ~40% with 16 threads.

**chr16 mini dataset (12 full haplotypes from 6 humans plus 2 references)**
`\time -v seqwish -s chr16hg00.fa.gz -p chr16hg00.paf -g graph.gfa -t 16 -B 1M -P`

master `Elapsed (wall clock) time (h:mm:ss or m:ss): 13:08.08`
branch `Elapsed (wall clock) time (h:mm:ss or m:ss): 7:44.57` --- **~40% faster**
