### PR TITLE
sparsify matches

### DIFF
--- a/src/alignments.hpp
+++ b/src/alignments.hpp
@@ -22,14 +22,20 @@ void paf_worker(
     std::mutex& paf_in_mutex,
     mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
     const seqindex_t& seqidx,
-    const uint64_t& min_match_len);
+    const uint64_t& min_match_len,
+    const float& sparsification_factor);
 
 void unpack_paf_alignments(
     const std::string& paf_file,
     mmmulti::iitree<uint64_t, pos_t>& aln_iitree,
     const seqindex_t& seqidx,
     const uint64_t& min_match_len,
+    const float& sparsification_factor,
     const uint64_t& num_threads);
+
+uint64_t match_hash(const pos_t& q, const pos_t& t, const uint64_t& l);
+
+bool keep_sparse(const pos_t& q, const pos_t& t, const uint64_t& l, const float f);
 
 
 /*


### PR DESCRIPTION
Implements world min-hash sparsification for input matches. For very large all-to-all alignments, we can randomly remove most matches and still have a coherent graph. By sparsifying at the level of exact matches rather than mappings, we retain long range information from the input alignment set.