### PR TITLE
Fix the build for Linux ARM64

### DIFF
--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -48,7 +48,7 @@ jobs:
             --volume "${PWD}:/seqwish"
           install: |
             apt-get update -q -y
-            apt-get install -q -y sudo apt-get install -y
+            apt-get install -q -y
               git
               bash
               cmake

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -52,6 +52,7 @@ jobs:
               make \
               g++ \
               git \
+              file \
               libatomic-ops-dev \
               autoconf \
               libgsl-dev \

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -5,9 +5,19 @@ name: build and test
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-latest
+            arch: aarch64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with: 
+          submodules: 'recursive'
       - name: Install required packages
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: sudo apt-get update && sudo apt-get install -y
           git
           bash
@@ -20,10 +30,37 @@ jobs:
           zlib1g-dev
           libzstd-dev
           libjemalloc-dev
-      - name: Init and update submodules
-        run: git submodule update --init --recursive
-      - name: Build seqwish
+      - name: Build seqwish for Linux x86_64
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: cmake -H. -DCMAKE_BUILD_TYPE=Debug -Bbuild && cmake --build build -- -j 2
-      - name: Execute tests
+      - name: Execute tests for Linux x86_64
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: cd test && ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 make test
 
+      - name: Build and test seqwish for Linux ${{ matrix.arch }}
+        if: matrix.os == 'ubuntu-latest' && matrix.arch != 'x86_64'
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          dockerRunArgs: |
+            --volume "${PWD}:/seqwish"
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y sudo apt-get install -y
+              git
+              bash
+              cmake
+              make
+              g++
+              libatomic-ops-dev
+              autoconf
+              libgsl-dev
+              zlib1g-dev
+              libzstd-dev
+              libjemalloc-dev
+          run: |
+            cd /seqwish
+            cmake -H. -DCMAKE_BUILD_TYPE=Debug -Bbuild && cmake --build build -- -j 2
+            cd test && ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 make test

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -44,7 +44,6 @@ jobs:
           githubToken: ${{ github.token }}
           dockerRunArgs: |
             --volume "${PWD}:/seqwish" 
-            --cap-add=ALL
           install: |
             apt-get update -q -y
             apt-get install -q -y \
@@ -63,4 +62,4 @@ jobs:
             cd /seqwish
             cmake -H. -DCMAKE_BUILD_TYPE=Debug -Bbuild && cmake --build build -- -j 2
             file bin/seqwish 
-            cd test && ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 make test
+            cd test && make test

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -49,6 +49,7 @@ jobs:
               cmake \
               make \
               g++ \
+              file \
               libatomic-ops-dev \
               autoconf \
               libgsl-dev \

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -60,6 +60,6 @@ jobs:
               libjemalloc-dev
           run: |
             cd /seqwish
-            cmake -H. -DCMAKE_BUILD_TYPE=Debug -Bbuild && cmake --build build -- -j 2
+            cmake -H. -DCMAKE_BUILD_TYPE=Release -Bbuild && cmake --build build -- -j 2
             file bin/seqwish 
             cd test && make test

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -30,7 +30,7 @@ jobs:
           libjemalloc-dev
       - name: Build seqwish for Linux x86_64
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
-        run: cmake -H. -DCMAKE_BUILD_TYPE=Debug -Bbuild && cmake --build build -- -j 2
+        run: cmake -H. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-mcx16" -DCMAKE_CXX_FLAGS="-mcx16" -Bbuild && cmake --build build -- -j 2
       - name: Execute tests for Linux x86_64
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: cd test && ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 make test

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -42,14 +42,16 @@ jobs:
           arch: ${{ matrix.arch }}
           distro: ubuntu20.04
           githubToken: ${{ github.token }}
-          dockerRunArgs: --volume "${PWD}:/seqwish" --cap-add=ALL
+          dockerRunArgs: |
+            --volume "${PWD}:/seqwish" 
+            --cap-add=ALL
           install: |
             apt-get update -q -y
             apt-get install -q -y \
               cmake \
               make \
               g++ \
-              file \
+              git \
               libatomic-ops-dev \
               autoconf \
               libgsl-dev \

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Install required packages
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: sudo apt-get update && sudo apt-get install -y
+          git
+          bash
           cmake
           make
           g++

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -42,8 +42,7 @@ jobs:
           arch: ${{ matrix.arch }}
           distro: ubuntu20.04
           githubToken: ${{ github.token }}
-          dockerRunArgs: |
-            --volume "${PWD}:/seqwish"
+          dockerRunArgs: --volume "${PWD}:/seqwish" --cap-add SYS_PTRACE
           install: |
             apt-get update -q -y
             apt-get install -q -y \
@@ -59,4 +58,5 @@ jobs:
           run: |
             cd /seqwish
             cmake -H. -DCMAKE_BUILD_TYPE=Debug -Bbuild && cmake --build build -- -j 2
+            file bin/seqwish 
             cd test && ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 make test

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -42,7 +42,7 @@ jobs:
           arch: ${{ matrix.arch }}
           distro: ubuntu20.04
           githubToken: ${{ github.token }}
-          dockerRunArgs: --volume "${PWD}:/seqwish" --cap-add SYS_PTRACE
+          dockerRunArgs: --volume "${PWD}:/seqwish" --cap-add=ALL
           install: |
             apt-get update -q -y
             apt-get install -q -y \

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -19,8 +19,6 @@ jobs:
       - name: Install required packages
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: sudo apt-get update && sudo apt-get install -y
-          git
-          bash
           cmake
           make
           g++
@@ -48,17 +46,15 @@ jobs:
             --volume "${PWD}:/seqwish"
           install: |
             apt-get update -q -y
-            apt-get install -q -y
-              git
-              bash
-              cmake
-              make
-              g++
-              libatomic-ops-dev
-              autoconf
-              libgsl-dev
-              zlib1g-dev
-              libzstd-dev
+            apt-get install -q -y \
+              cmake \
+              make \
+              g++ \
+              libatomic-ops-dev \
+              autoconf \
+              libgsl-dev \
+              zlib1g-dev \
+              libzstd-dev \
               libjemalloc-dev
           run: |
             cd /seqwish

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,12 @@ endif ()
 
 if (${CMAKE_BUILD_TYPE} MATCHES Debug)
   # Debug use the defaults
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -mcx16 -g -fsanitize=address")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -mcx16 -g -fsanitize=address")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
 else()
   # Use all standard-compliant optimizations - always add these:
-  set (CMAKE_C_FLAGS "${OpenMP_C_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS} -mcx16")
-  set (CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS} -mcx16")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS}")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS}")
 endif ()
 
 # Set the output folder where your program will be created


### PR DESCRIPTION
Pass '-mcx16' as a CMake option only for x86_64.
Run the build and tests in a Docker container for ARM64. Do not use sanitizers because they are not usable without ptrace (in container).