### PR TITLE
Issue #104 - Use -march=native as default

### DIFF
--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -1,4 +1,4 @@
-on: [ push ]
+on: [ push, pull_request ]
 
 name: build and test
 
@@ -62,6 +62,6 @@ jobs:
               libjemalloc-dev
           run: |
             cd /seqwish
-            cmake -H. -DCMAKE_BUILD_TYPE=Release -Bbuild && cmake --build build -- -j 2
+            cmake -H. -DCMAKE_BUILD_TYPE=Release -DEXTRA_FLAGS="-march=armv8-a" -Bbuild && cmake --build build -- -j 2
             file bin/seqwish 
             cd test && make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 
 if(NOT DEFINED EXTRA_FLAGS)
-  set(EXTRA_FLAGS "-march=haswell" CACHE STRING
+  set(EXTRA_FLAGS "-march=native" CACHE STRING
           "Extra compilation flags for C and CXX." FORCE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,14 @@ endif()
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 
+if(NOT DEFINED EXTRA_FLAGS)
+  set(EXTRA_FLAGS "-march=haswell" CACHE STRING
+          "Extra compilation flags for C and CXX." FORCE)
+endif()
+
 if (${CMAKE_BUILD_TYPE} MATCHES Release)
-  set(EXTRA_FLAGS "-Ofast -march=native")
+  set(EXTRA_FLAGS "-Ofast ${EXTRA_FLAGS}")
   set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG") # reset CXX_FLAGS to replace -O3 with -Ofast
-else()
-  set(EXTRA_FLAGS "-march=haswell")
 endif ()
 
 if (${CMAKE_BUILD_TYPE} MATCHES Debug)


### PR DESCRIPTION
Make it possible to overwrite it with -DEXTRA_FLAGS="-march=armv8-a"

Related-to: #104 