### PR TITLE
Remove uses of get_current_dir_name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,9 +116,9 @@ int main(int argc, char** argv) {
     if (tmp_base) {
         temp_file::set_dir(args::get(tmp_base));
     } else {
-        char* cwd = get_current_dir_name();
+        char cwd[512];
+        getcwd(cwd, sizeof(cwd));
         temp_file::set_dir(std::string(cwd));
-        free(cwd);
     }
 
     temp_file::set_keep_temp(args::get(keep_temp_files));

--- a/src/tempfile.cpp
+++ b/src/tempfile.cpp
@@ -96,9 +96,9 @@ namespace temp_file {
 
         // Get the default temp dir from environment variables.
         if (temp_dir.empty()) {
-            char* cwd = get_current_dir_name();
+            char cwd[512];
+            getcwd(cwd, sizeof(cwd));
             temp_dir = std::string(cwd);
-            free(cwd);
             /*const char *system_temp_dir = nullptr;
             for (const char *var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
                 if (system_temp_dir == nullptr) {


### PR DESCRIPTION
This pull request removes get_current_dir_name to make seqwish easier to compile on macOS.
- https://github.com/ekg/seqwish/issues/117

Created based on the following pull request
- https://github.com/pangenome/odgi/pull/494/commits/ef57bea30162e7213b57c5eaec8c74c50fa3f0a1