### PR TITLE
Do not use -latomic on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ target_link_libraries(seqwish
   "${sdsl-lite_LIB}/libsdsl.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
-  "-latomic"
+  $<$<NOT:$<STREQUAL:${CMAKE_SYSTEM_NAME},Darwin>>:-latomic>
   Threads::Threads
   jemalloc
   z)


### PR DESCRIPTION
This pull request is to avoid specifying -latomic on macOS.
- https://github.com/ekg/seqwish/issues/117

I refer to the following pull request.
- https://github.com/pangenome/odgi/pull/494/commits/33fc8ca4b2c30a0f751f55f2fba3ea200902e526