### PR TITLE
Set number of threads for ips4o::parallel::sort

### DIFF
--- a/src/transclosure.cpp
+++ b/src/transclosure.cpp
@@ -534,7 +534,7 @@ size_t compute_transitive_closures(
 #ifdef DEBUG_TRANSCLOSURE
         if (show_progress) std::cerr << "[seqwish::transclosure] " << std::fixed << std::showpoint << std::setprecision(3) << seconds_since(start_time) << " " << std::setprecision(2) << (double)bases_seen / (double)seqidx.seq_length() * 100 << "% " << chunk_start << "-" << chunk_end << " dset_compression" << std::endl;
 #endif
-        ips4o::parallel::sort(dsets.begin(), dsets.end());
+        ips4o::parallel::sort(dsets.begin(), dsets.end(), std::less<>(), num_threads);
 
         uint64_t c = 0;
         assert(dsets.size());
@@ -564,7 +564,7 @@ size_t compute_transitive_closures(
             uint64_t& minpos = dsets_by_min_pos[d.first].first;
             minpos = std::min(minpos, d.second);
         }
-        ips4o::parallel::sort(dsets_by_min_pos.begin(), dsets_by_min_pos.end());
+        ips4o::parallel::sort(dsets_by_min_pos.begin(), dsets_by_min_pos.end(), std::less<>(), num_threads);
         /*
         for (auto& d : dsets_by_min_pos) {
             std::cerr << "sdset_min_pos\t" << d.second << "\t" << d.first << std::endl;
@@ -583,7 +583,7 @@ size_t compute_transitive_closures(
         for (auto& d : dsets) {
             d.first = dset_names[d.first];
         }
-        ips4o::parallel::sort(dsets.begin(), dsets.end());
+        ips4o::parallel::sort(dsets.begin(), dsets.end(), std::less<>(), num_threads);
         /*
         for (auto& d : dsets) {
             std::cerr << "sdset_rename\t" << d.first << "\t" << pos_to_string(d.second) << std::endl;


### PR DESCRIPTION
@ekg @AndreaGuarracino 
By default, ips4o::parallel::sort uses all available threads [[see]](https://github.com/SaschaWitt/ips4o/blob/9adfd8f04f3151fd21838a7ad60e70b36c4c6db2/ips4o/ips4o.hpp#L138). During each transclosure step the CPU utilization briefly spiked (higher than configured with the `--threads` argument). This sets the number of threads used during sorting to match the `--threads` argument.

Fixes #124. 