### PR TITLE
added checks for apple sillicon

### DIFF
--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -61,7 +61,7 @@ jobs:
               zlib1g-dev \
               libzstd-dev \
               libjemalloc-dev \
-              libpthread-stubs0-dev
+              libpthread-stubs0-dev \
               pkg-config
           run: |
             cd /seqwish

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -30,6 +30,7 @@ jobs:
           zlib1g-dev
           libzstd-dev
           libjemalloc-dev
+          pkg-config
       - name: Build seqwish for Linux x86_64
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64'
         run: cmake -H. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-mcx16" -DCMAKE_CXX_FLAGS="-mcx16" -Bbuild && cmake --build build -- -j 2

--- a/.github/workflows/build_and_test_on_push.yml
+++ b/.github/workflows/build_and_test_on_push.yml
@@ -61,6 +61,7 @@ jobs:
               libzstd-dev \
               libjemalloc-dev \
               libpthread-stubs0-dev
+              pkg-config
           run: |
             cd /seqwish
             cmake -H. -DCMAKE_BUILD_TYPE=Release -DEXTRA_FLAGS="-march=armv8-a -pthread" -Bbuild && cmake --build build -- -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,24 @@ set(CMAKE_CXX_STANDARD 14)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+# --- Start: Logic for using JEMALLOC on Apple Silicon ---
+set(JEMALLOC_LINK_LIBRARIES "jemalloc")
+
+if (APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64"))
+  pkg_check_modules(HOMEBREW_JEMALLOC QUIET jemalloc)
+  if (HOMEBREW_JEMALLOC_FOUND)
+    set(JEMALLOC_LINK_LIBRARIES ${HOMEBREW_JEMALLOC_LINK_LIBRARIES})
+    message(STATUS "Apple Silicon: Found Homebrew Jemalloc. Will use it.")
+    message(STATUS "  Homebrew jemalloc Includes: ${HOMEBREW_JEMALLOC_INCLUDE_DIRS}")
+    message(STATUS "  Homebrew jemalloc Link Libraries: ${HOMEBREW_JEMALLOC_LINK_LIBRARIES}")
+  else()
+    message(WARNING "Apple Silicon: Homebrew jemalloc not found via pkg-config. Will try using default jemalloc.")
+  endif ()
+  message(STATUS "jemalloc Link Library: ${JEMALLOC_LINK_LIBRARIES}")
+endif ()
+# --- End: Logic for using Homebrew HTSlib, GSL, and LibDeflate on Apple Silicon ---
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING
@@ -78,6 +96,11 @@ include_directories("${PROJECT_SOURCE_DIR}")
 
 # Add external projects
 include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "4.0")
+  # Compatibility with CMake < 3.5 has been removed from CMake starting 4.0
+  set(CMAKE_ARGS "${CMAKE_ARGS};-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+endif()
 
 # sdsl-lite (full build using its cmake config)
 ExternalProject_Add(sdsl-lite
@@ -256,10 +279,15 @@ target_link_libraries(seqwish
   "${sdsl-lite_LIB}/libsdsl.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
-  "-latomic"
   Threads::Threads
-  jemalloc
+  "${JEMALLOC_LINK_LIBRARIES}"
   z)
+
+# macOS does not need `-latomic` to use atomics.
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_link_libraries(seqwish "-latomic")
+endif()
+
 if (BUILD_STATIC)
   #set(CMAKE_EXE_LINKER_FLAGS "-static")
   set(CMAKE_EXE_LINKER_FLAGS "-static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,9 +116,9 @@ int main(int argc, char** argv) {
     if (tmp_base) {
         temp_file::set_dir(args::get(tmp_base));
     } else {
-        char* cwd = get_current_dir_name();
+        char cwd[512];
+        getcwd(cwd, sizeof(cwd));
         temp_file::set_dir(std::string(cwd));
-        free(cwd);
     }
 
     temp_file::set_keep_temp(args::get(keep_temp_files));

--- a/src/tempfile.cpp
+++ b/src/tempfile.cpp
@@ -96,9 +96,9 @@ namespace temp_file {
 
         // Get the default temp dir from environment variables.
         if (temp_dir.empty()) {
-            char* cwd = get_current_dir_name();
+            char cwd[512];
+            getcwd(cwd, sizeof(cwd));
             temp_dir = std::string(cwd);
-            free(cwd);
             /*const char *system_temp_dir = nullptr;
             for (const char *var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
                 if (system_temp_dir == nullptr) {


### PR DESCRIPTION
Was able to successfully build SEQWISH on M2 Mac Pro with these changes. 

The primary errors that were seen:
1. CMake has removed direct compatibility with versions older than 3.5 starting 4.0. This led to errors when version < 3.5 was specified in cmake_minimum_required. The fix was to add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` flag to override the minimum version.
2. `jemalloc` lib is usualy installed via homebrew in mac. Added support to identify and link homebrew libraries.
3. removed linking of -latomi if the sytem is macos
4. `get_current_dir_name` is a GNU-ism; I've replaced it with the standard `getcwd`.

System Description:

```
cmake version 4.0.3

Homebrew clang version 17.0.6
Target: arm64-apple-darwin24.5.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm@17/bin

$CPPFLAGS
-I/opt/homebrew/opt/zlib/include -I/opt/homebrew/opt/libomp/include -I/opt/homebrew/opt/llvm@17/include

$LDFLAGS
-L/opt/homebrew/opt/zlib/lib -L/opt/homebrew/opt/libomp/lib -L/opt/homebrew/opt/llvm@17/lib

$PKG_CONFIG_PATH
/opt/homebrew/lib/pkgconfig:
```

Build Description:

```
 cmake -H. -Bbuild -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build build -- -j 3
```


References: 
1. https://github.com/ekg/seqwish/issues/117
2. https://github.com/pangenome/odgi/pull/494
3. https://github.com/waveygang/wfmash/pull/361
