### PR TITLE
Fix -t 1 hang in transitive closure

### DIFF
--- a/src/transclosure.rs
+++ b/src/transclosure.rs
@@ -273,6 +273,7 @@ fn explore_overlaps_discovery(
     todo_in: &RangeAtomicQueue,
     seqidx: &SeqIndex,
     spanning_adj: &SpanningTreeAdj,
+    pending: &AtomicU64,
 ) {
     let source_seq = seqidx.seq_id_at(b.start).unwrap_or(0);
 
@@ -307,6 +308,8 @@ fn explore_overlaps_discovery(
                 }
                 if !all_set_there {
                     let item = (make_pos_t(offset(s.data), is_rev(s.data)), s.end - s.start);
+                    // count before it is visible in todo_in
+                    pending.fetch_add(1, Ordering::SeqCst);
                     while todo_in.push(item).is_err() {
                         std::thread::yield_now();
                     }
@@ -634,7 +637,9 @@ pub fn compute_transitive_closures(
         let todo_in = Arc::new(ArrayQueue::new(131072));
         let todo_out = Arc::new(ArrayQueue::new(131072));
         let mut todo: VecDeque<(PosT, u64)> = VecDeque::new();
-        let active_workers = Arc::new(AtomicU64::new(0));
+        // Outstanding BFS items (queued or in-flight). pending == 0 is the race-free
+        // termination signal: an item is counted before it is visible to consumers.
+        let pending = Arc::new(AtomicU64::new(0));
 
         // Seed initial ranges
         for_each_fresh_range(
@@ -645,6 +650,7 @@ pub fn compute_transitive_closures(
                     q_curr_bv.set(j as usize, true, Ordering::Release);
                 }
                 let range = (make_pos_t(b.start, false), b.end - b.start);
+                pending.fetch_add(1, Ordering::SeqCst);
                 if todo_out.push(range).is_err() {
                     todo.push_back(range);
                 }
@@ -657,6 +663,38 @@ pub fn compute_transitive_closures(
         let q_curr_bv_shared = Arc::new(q_curr_bv);
         let spanning_pairs_ref = &spanning_pairs;
 
+        // Manager shuttles todo_in -> todo -> todo_out on a dedicated OS thread, not a
+        // rayon task: busy-spinning workers can saturate a small pool (e.g. -t 1) and
+        // starve a scoped manager, deadlocking PHASE 1.
+        let todo_in_mgr = Arc::clone(&todo_in);
+        let todo_out_mgr = Arc::clone(&todo_out);
+        let pending_mgr = Arc::clone(&pending);
+        let manager = thread::spawn(move || {
+            let mut todo = todo;
+            loop {
+                let mut did_work = false;
+                while let Some(item) = todo_in_mgr.pop() {
+                    todo.push_back(item);
+                    did_work = true;
+                }
+                while let Some(item) = todo.front().copied() {
+                    if todo_out_mgr.push(item).is_ok() {
+                        todo.pop_front();
+                        did_work = true;
+                    } else {
+                        break;
+                    }
+                }
+                if !did_work {
+                    // exit only when the BFS is fully drained
+                    if pending_mgr.load(Ordering::SeqCst) == 0 {
+                        break;
+                    }
+                    std::thread::yield_now();
+                }
+            }
+        });
+
         rayon::scope(|s| {
             for _worker_idx in 0..(num_threads * 2) {
                 let todo_out = Arc::clone(&todo_out);
@@ -666,13 +704,10 @@ pub fn compute_transitive_closures(
                 let q_seen_bv_clone = q_seen_bv.clone();
                 let seqidx = Arc::clone(&seqidx_clone);
 
-                let active_workers_clone = Arc::clone(&active_workers);
+                let pending_clone = Arc::clone(&pending);
                 s.spawn(move |_s| {
-                    let mut empty_count = 0u64;
                     loop {
                         if let Some((pos, match_len)) = todo_out.pop() {
-                            empty_count = 0;
-                            active_workers_clone.fetch_add(1, Ordering::SeqCst);
                             let n = if !is_rev(pos) {
                                 offset(pos)
                             } else {
@@ -687,65 +722,20 @@ pub fn compute_transitive_closures(
                                 &todo_in,
                                 &seqidx,
                                 spanning_pairs_ref,
+                                &pending_clone,
                             );
-                            active_workers_clone.fetch_sub(1, Ordering::SeqCst);
+                            // decrement parent only after explore counted its children
+                            pending_clone.fetch_sub(1, Ordering::SeqCst);
+                        } else if pending_clone.load(Ordering::SeqCst) == 0 {
+                            break;
                         } else {
                             std::thread::yield_now();
-                            empty_count += 1;
-                            let to_empty = todo_out.is_empty();
-                            let ti_empty = todo_in.is_empty();
-                            let no_active = active_workers_clone.load(Ordering::SeqCst) == 0;
-                            if to_empty && ti_empty && no_active {
-                                if empty_count > 1000 {
-                                    break;
-                                }
-                            } else if !no_active {
-                                empty_count = 0;
-                            }
                         }
                     }
                 });
             }
-
-            // Manager task — shuttles todo_in → todo → todo_out (no ovlp_q to drain)
-            let active_workers_mgr = Arc::clone(&active_workers);
-            s.spawn(move |_s| {
-                let mut empty_count = 0;
-                loop {
-                    let mut did_work = false;
-                    while let Some(item) = todo_in.pop() {
-                        todo.push_back(item);
-                        did_work = true;
-                    }
-                    while let Some(item) = todo.front().copied() {
-                        if todo_out.push(item).is_ok() {
-                            todo.pop_front();
-                            did_work = true;
-                        } else {
-                            break;
-                        }
-                    }
-                    if did_work {
-                        empty_count = 0;
-                    } else {
-                        std::thread::yield_now();
-                        empty_count += 1;
-                        let no_active = active_workers_mgr.load(Ordering::SeqCst) == 0;
-                        if empty_count > 1000
-                            && todo.is_empty()
-                            && todo_in.is_empty()
-                            && todo_out.is_empty()
-                            && no_active
-                        {
-                            break;
-                        }
-                        if !no_active {
-                            empty_count = 0;
-                        }
-                    }
-                }
-            });
         });
+        manager.join().unwrap();
 
         if show_progress {
             eprintln!(

--- a/src/transclosure.rs
+++ b/src/transclosure.rs
@@ -357,7 +357,7 @@ fn write_graph_chunk(
         if curr_dset_id != last_dset_id {
             if repeat_max != 0 || min_repeat_dist != 0 {
                 // Flush todos inline
-                for (_count, positions) in todos.iter() {
+                for positions in todos.values() {
                     seq_v_out.push(current_base);
                     seq_v_length += 1;
                     for pos in positions {
@@ -419,7 +419,7 @@ fn write_graph_chunk(
     }
 
     // Flush remaining todos
-    for (_count, positions) in todos.iter() {
+    for positions in todos.values() {
         seq_v_out.push(current_base);
         seq_v_length += 1;
         for pos in positions {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -240,6 +240,38 @@ fn test_pipeline_memory_mode_basic() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn test_single_thread_pool_no_deadlock() {
+    // Regression for the -t 1 deadlock: the CLI sizes rayon's global pool to
+    // --threads, so -t 1 ran the BFS on a 1-thread pool and starved the manager.
+    // Other tests miss it by running on rayon's default multi-core pool. Run under
+    // a watchdog so a regression fails fast instead of hanging CI.
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let result = pool.install(|| run_pipeline(true).map_err(|e| e.to_string()));
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(Duration::from_secs(30)) {
+        Ok(Ok(gfa)) => {
+            assert!(gfa.contains("S\t"), "GFA should contain segments");
+            assert!(gfa.contains("P\t"), "GFA should contain paths");
+            handle.join().unwrap();
+        }
+        Ok(Err(e)) => panic!("pipeline errored on a single-thread pool: {e}"),
+        Err(_) => {
+            panic!("transitive closure deadlocked on a single-thread rayon pool (-t 1 regression)")
+        }
+    }
+}
+
+#[test]
 fn test_pipeline_disk_mode_basic() -> Result<(), Box<dyn std::error::Error>> {
     // Run disk-backed pipeline and verify it produces valid output
     let gfa = run_pipeline(false)?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,8 +10,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Helper function to run full pipeline and return GFA output
 fn run_pipeline(in_memory: bool) -> Result<String, Box<dyn std::error::Error>> {
-    // Create unique temporary paths
-    let unique_id = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    // Unique temp paths per call: a timestamp alone collides under concurrent
+    // tests (coarse clock), so disambiguate with an atomic counter.
+    static RUN_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let unique_id = format!(
+        "{}_{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos(),
+        RUN_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    );
     let fasta_path = format!("/tmp/test_pipeline_{}_{}.fasta", unique_id, in_memory);
     let paf_path = format!("/tmp/test_pipeline_{}_{}.paf.gz", unique_id, in_memory);
     let base_dir = format!("/tmp/test_pipeline_{}_{}", unique_id, in_memory);


### PR DESCRIPTION
Fixes #116

Default `-t 1` deadlocks in the transitive-closure BFS: the manager task starves on the single-thread rayon pool. This blocked graph induction under the default settings (the 0-length dead-end nodes from #116 are already gone in the Rust output).

- manager runs on a dedicated OS thread, not a rayon scope task
- termination via a race-free outstanding-work counter
- regression test on a 1-thread pool (hangs before, 0.01s after)

Byte-identical to the C++ reference on HLA at `-t 1`.