### PR TITLE
Packaging fixes for source and tarball builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "target-cpu=native"]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ experiments/
 *#*
 include
 target/
+# Local, opt-in build tuning; never shipped.
+.cargo/config.toml

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ cargo build --release
 # Binary will be in target/release/seqwish
 ```
 
+For a faster binary on the same computer you build on, run:
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+```
+
+This binary may not work on other computers, so do not use it for packages you share.
+
 ### from crates.io after publication
 
 ```bash

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,10 +3,11 @@ use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::raw::c_char;
 
-// Git version injected at build time - fallback to "unknown" if not set
+// Git version injected at build time; fall back to the crate version when
+// git is unavailable (e.g. building from a release tarball or crates.io).
 const GIT_VERSION: &str = match option_env!("SEQWISH_GIT_VERSION") {
     Some(v) => v,
-    None => "unknown",
+    None => env!("CARGO_PKG_VERSION"),
 };
 
 static CODENAMES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {


### PR DESCRIPTION
Fixes the two packaging notes in #145:

- `--version` falls back to `CARGO_PKG_VERSION` instead of `unknown` when built without git (tarball / crates.io).
- `.cargo/config.toml` no longer ships `target-cpu=native`; it is now a documented `RUSTFLAGS` opt-in.

Closes #145.