### PR TITLE
Drop .cargo/config.toml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ experiments/
 *#*
 include
 target/
-# Local, opt-in build tuning; never shipped.
-.cargo/config.toml


### PR DESCRIPTION
Reverts the .gitignore addition from #146.